### PR TITLE
Drop support for python3.8.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v3

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ setup(
     long_description=Path("README.md").read_text(),
     long_description_content_type="text/markdown",
     classifiers=[
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Topic :: Software Development :: Libraries :: Python Modules",
@@ -20,7 +19,7 @@ setup(
     author="David Knowles",
     author_email="dknowles2@gmail.com",
     packages=find_packages(),
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     url="https://github.com/dknowles2/pydrawise",
     license="Apache License 2.0",
     install_requires=[


### PR DESCRIPTION
It doesn't incude the @cache decorator in the functools module.