### PR TITLE
Make update_controller_info return a bool

### DIFF
--- a/pydrawise/legacy/__init__.py
+++ b/pydrawise/legacy/__init__.py
@@ -74,9 +74,10 @@ class LegacyHydrawise:
     def running(self) -> str | None:
         return self.controller_status.get("running")
 
-    def update_controller_info(self) -> None:
+    def update_controller_info(self) -> bool:
         self.controller_info = self._get_controller_info()
         self.controller_status = self._get_controller_status()
+        return True
 
     def _get(self, path: str, **kwargs) -> dict:
         url = f"{_BASE_URL}/{path}"


### PR DESCRIPTION
The legacy hydrawiser library did this, and the HA integration expects this to happen. Without this, all entities in HA will show as unavailable. 