### PR TITLE
Fix some bugs with run and suspend

### DIFF
--- a/pydrawise/legacy/__init__.py
+++ b/pydrawise/legacy/__init__.py
@@ -104,7 +104,7 @@ class LegacyHydrawise:
         params = {}
 
         if days > 0:
-            params["custom"] = time.time() + (days * 24 * 60 * 60)
+            params["custom"] = int(time.time() + (days * 24 * 60 * 60))
             params["period_id"] = 999
         else:
             params["period_id"] = 0
@@ -132,7 +132,7 @@ class LegacyHydrawise:
             params["action"] = "runall" if minutes > 0 else "stopall"
 
         if minutes > 0:
-            params["custom"] = time.time() + (minutes * 60)
+            params["custom"] = minutes * 60
             params["period_id"] = 999
         else:
             params["period_id"] = 0

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -396,14 +396,14 @@ def test_suspend_zone(mock_request, success_status):
     mock_request.return_value.status_code = 200
     mock_request.return_value.json.return_value = success_status
 
-    with freeze_time("1970-01-01 00:00:00") as t:
+    with freeze_time("2023-01-01 00:00:00") as t:
         assert client.suspend_zone(1, 1) == success_status
         mock_request.assert_called_once_with(
             "https://api.hydrawise.com/api/v1/setzone.php",
             params={
                 "api_key": API_KEY,
                 "action": "suspend",
-                "custom": 86400,
+                "custom": 1672617600,
                 "period_id": 999,
                 "relay_id": 428639,
             },
@@ -418,7 +418,7 @@ def test_suspend_zone_unsuspend(mock_request, success_status):
     mock_request.return_value.status_code = 200
     mock_request.return_value.json.return_value = success_status
 
-    with freeze_time("1970-01-01 00:00:00") as t:
+    with freeze_time("2023-01-01 00:00:00") as t:
         assert client.suspend_zone(0, 1) == success_status
         mock_request.assert_called_once_with(
             "https://api.hydrawise.com/api/v1/setzone.php",
@@ -439,14 +439,14 @@ def test_suspend_zone_all(mock_request, success_status):
     mock_request.return_value.status_code = 200
     mock_request.return_value.json.return_value = success_status
 
-    with freeze_time("1970-01-01 00:00:00") as t:
+    with freeze_time("2023-01-01 00:00:00") as t:
         assert client.suspend_zone(1) == success_status
         mock_request.assert_called_once_with(
             "https://api.hydrawise.com/api/v1/setzone.php",
             params={
                 "api_key": API_KEY,
                 "action": "suspendall",
-                "custom": 86400,
+                "custom": 1672617600,
                 "period_id": 999,
             },
             timeout=10,
@@ -460,7 +460,7 @@ def test_run_zone(mock_request, success_status):
     mock_request.return_value.status_code = 200
     mock_request.return_value.json.return_value = success_status
 
-    with freeze_time("1970-01-01 00:00:00") as t:
+    with freeze_time("2023-01-01 00:00:00") as t:
         assert client.run_zone(1, 1) == success_status
         mock_request.assert_called_once_with(
             "https://api.hydrawise.com/api/v1/setzone.php",
@@ -482,7 +482,7 @@ def test_run_zone_all(mock_request, success_status):
     mock_request.return_value.status_code = 200
     mock_request.return_value.json.return_value = success_status
 
-    with freeze_time("1970-01-01 00:00:00") as t:
+    with freeze_time("2023-01-01 00:00:00") as t:
         assert client.run_zone(1) == success_status
         mock_request.assert_called_once_with(
             "https://api.hydrawise.com/api/v1/setzone.php",
@@ -503,7 +503,7 @@ def test_run_zone_stop(mock_request, success_status):
     mock_request.return_value.status_code = 200
     mock_request.return_value.json.return_value = success_status
 
-    with freeze_time("1970-01-01 00:00:00") as t:
+    with freeze_time("2023-01-01 00:00:00") as t:
         assert client.run_zone(0, 1) == success_status
         mock_request.assert_called_once_with(
             "https://api.hydrawise.com/api/v1/setzone.php",
@@ -524,7 +524,7 @@ def test_run_zone_stop_all(mock_request, success_status):
     mock_request.return_value.status_code = 200
     mock_request.return_value.json.return_value = success_status
 
-    with freeze_time("1970-01-01 00:00:00") as t:
+    with freeze_time("2023-01-01 00:00:00") as t:
         assert client.run_zone(0) == success_status
         mock_request.assert_called_once_with(
             "https://api.hydrawise.com/api/v1/setzone.php",


### PR DESCRIPTION
1.  The suspend call takes an integer timestamp
2.  The run call takes a run duration, not a timestamp


As reported in https://github.com/home-assistant/core/issues/98850
I think this will also resolve https://github.com/home-assistant/core/issues/98231