### PR TITLE
Add an async implementation of the legacy API

### DIFF
--- a/pydrawise/__init__.py
+++ b/pydrawise/__init__.py
@@ -1,6 +1,7 @@
 """API for interacting with Hydrawise sprinkler controllers."""
 
 from .auth import Auth
+from .base import HydrawiseBase
 from .client import Hydrawise
 from .exceptions import (
     Error,

--- a/pydrawise/base.py
+++ b/pydrawise/base.py
@@ -1,0 +1,131 @@
+"""Base class for the Hydrawise client API."""
+
+from abc import ABC, abstractmethod
+from datetime import datetime
+
+from .schema import Controller, User, Zone, ZoneSuspension
+
+
+class HydrawiseBase(ABC):
+    """Base class for Hydrawise client APIs."""
+
+    @abstractmethod
+    async def get_user(self) -> User:
+        """Retrieves the currently authenticated user.
+
+        :rtype: User
+        """
+
+    @abstractmethod
+    async def get_controllers(self) -> list[Controller]:
+        """Retrieves all controllers associated with the currently authenticated user.
+
+        :rtype: list[Controller]
+        """
+
+    @abstractmethod
+    async def get_controller(self, controller_id: int) -> Controller:
+        """Retrieves a single controller by its unique identifier.
+
+        :param controller_id: Unique identifier for the controller to retrieve.
+        :rtype: Controller
+        """
+
+    @abstractmethod
+    async def get_zones(self, controller: Controller) -> list[Zone]:
+        """Retrieves zones associated with the given controller.
+
+        :param controller: Controller whose zones to fetch.
+        :rtype: list[Zone]
+        """
+
+    @abstractmethod
+    async def get_zone(self, zone_id: int) -> Zone:
+        """Retrieves a zone by its unique identifier.
+
+        :param zone_id: The zone's unique identifier.
+        :rtype: Zone
+        """
+
+    @abstractmethod
+    async def start_zone(
+        self,
+        zone: Zone,
+        mark_run_as_scheduled: bool = False,
+        custom_run_duration: int = 0,
+    ):
+        """Starts a zone's run cycle.
+
+        :param zone: The zone to start.
+        :param mark_run_as_scheduled: Whether to mark the zone as having run as scheduled.
+        :param custom_run_duration: Duration (in seconds) to run the zone. If not
+            specified (or zero), will run for its default configured time.
+        """
+
+    @abstractmethod
+    async def stop_zone(self, zone: Zone):
+        """Stops a zone.
+
+        :param zone: The zone to stop.
+        """
+
+    @abstractmethod
+    async def start_all_zones(
+        self,
+        controller: Controller,
+        mark_run_as_scheduled: bool = False,
+        custom_run_duration: int = 0,
+    ):
+        """Starts all zones attached to a controller.
+
+        :param controller: The controller whose zones to start.
+        :param mark_run_as_scheduled: Whether to mark the zones as having run as scheduled.
+        :param custom_run_duration: Duration (in seconds) to run the zones. If not
+            specified (or zero), will run for each zone's default configured time.
+        """
+
+    @abstractmethod
+    async def stop_all_zones(self, controller: Controller):
+        """Stops all zones attached to a controller.
+
+        :param controller: The controller whose zones to stop.
+        """
+
+    @abstractmethod
+    async def suspend_zone(self, zone: Zone, until: datetime):
+        """Suspends a zone's schedule.
+
+        :param zone: The zone to suspend.
+        :param until: When the suspension should end.
+        """
+
+    @abstractmethod
+    async def resume_zone(self, zone: Zone):
+        """Resumes a zone's schedule.
+
+        :param zone: The zone whose schedule to resume.
+        """
+
+    @abstractmethod
+    async def suspend_all_zones(self, controller: Controller, until: datetime):
+        """Suspends the schedule of all zones attached to a given controller.
+
+        :param controller: The controller whose zones to suspend.
+        :param until: When the suspension should end.
+        """
+
+    @abstractmethod
+    async def resume_all_zones(self, controller: Controller):
+        """Resumes the schedule of all zones attached to the given controller.
+
+        :param controller: The controller whose zones to resume.
+        """
+
+    @abstractmethod
+    async def delete_zone_suspension(self, suspension: ZoneSuspension):
+        """Removes a specific zone suspension.
+
+        Useful when there are multiple suspensions for a zone in effect.
+
+        :param suspension: The suspension to delete.
+        """

--- a/pydrawise/base.py
+++ b/pydrawise/base.py
@@ -53,7 +53,7 @@ class HydrawiseBase(ABC):
         zone: Zone,
         mark_run_as_scheduled: bool = False,
         custom_run_duration: int = 0,
-    ):
+    ) -> None:
         """Starts a zone's run cycle.
 
         :param zone: The zone to start.
@@ -63,7 +63,7 @@ class HydrawiseBase(ABC):
         """
 
     @abstractmethod
-    async def stop_zone(self, zone: Zone):
+    async def stop_zone(self, zone: Zone) -> None:
         """Stops a zone.
 
         :param zone: The zone to stop.
@@ -75,7 +75,7 @@ class HydrawiseBase(ABC):
         controller: Controller,
         mark_run_as_scheduled: bool = False,
         custom_run_duration: int = 0,
-    ):
+    ) -> None:
         """Starts all zones attached to a controller.
 
         :param controller: The controller whose zones to start.
@@ -85,14 +85,14 @@ class HydrawiseBase(ABC):
         """
 
     @abstractmethod
-    async def stop_all_zones(self, controller: Controller):
+    async def stop_all_zones(self, controller: Controller) -> None:
         """Stops all zones attached to a controller.
 
         :param controller: The controller whose zones to stop.
         """
 
     @abstractmethod
-    async def suspend_zone(self, zone: Zone, until: datetime):
+    async def suspend_zone(self, zone: Zone, until: datetime) -> None:
         """Suspends a zone's schedule.
 
         :param zone: The zone to suspend.
@@ -100,14 +100,14 @@ class HydrawiseBase(ABC):
         """
 
     @abstractmethod
-    async def resume_zone(self, zone: Zone):
+    async def resume_zone(self, zone: Zone) -> None:
         """Resumes a zone's schedule.
 
         :param zone: The zone whose schedule to resume.
         """
 
     @abstractmethod
-    async def suspend_all_zones(self, controller: Controller, until: datetime):
+    async def suspend_all_zones(self, controller: Controller, until: datetime) -> None:
         """Suspends the schedule of all zones attached to a given controller.
 
         :param controller: The controller whose zones to suspend.
@@ -115,14 +115,14 @@ class HydrawiseBase(ABC):
         """
 
     @abstractmethod
-    async def resume_all_zones(self, controller: Controller):
+    async def resume_all_zones(self, controller: Controller) -> None:
         """Resumes the schedule of all zones attached to the given controller.
 
         :param controller: The controller whose zones to resume.
         """
 
     @abstractmethod
-    async def delete_zone_suspension(self, suspension: ZoneSuspension):
+    async def delete_zone_suspension(self, suspension: ZoneSuspension) -> None:
         """Removes a specific zone suspension.
 
         Useful when there are multiple suspensions for a zone in effect.

--- a/pydrawise/client.py
+++ b/pydrawise/client.py
@@ -12,6 +12,7 @@ from gql.transport.aiohttp import log as gql_log
 from graphql import GraphQLSchema
 
 from .auth import Auth
+from .base import HydrawiseBase
 from .exceptions import MutationError
 from .schema import (
     Controller,
@@ -39,7 +40,7 @@ def _get_schema() -> GraphQLSchema:
     )
 
 
-class Hydrawise:
+class Hydrawise(HydrawiseBase):
     """Client library for interacting with Hydrawise sprinkler controllers.
 
     Should be instantiated with an Auth object that handles authentication and low-level transport.

--- a/pydrawise/client.py
+++ b/pydrawise/client.py
@@ -138,7 +138,7 @@ class Hydrawise(HydrawiseBase):
         zone: Zone,
         mark_run_as_scheduled: bool = False,
         custom_run_duration: int = 0,
-    ):
+    ) -> None:
         """Starts a zone's run cycle.
 
         :param zone: The zone to start.
@@ -158,7 +158,7 @@ class Hydrawise(HydrawiseBase):
         )
         await self._mutation(selector)
 
-    async def stop_zone(self, zone: Zone):
+    async def stop_zone(self, zone: Zone) -> None:
         """Stops a zone.
 
         :param zone: The zone to stop.
@@ -173,7 +173,7 @@ class Hydrawise(HydrawiseBase):
         controller: Controller,
         mark_run_as_scheduled: bool = False,
         custom_run_duration: int = 0,
-    ):
+    ) -> None:
         """Starts all zones attached to a controller.
 
         :param controller: The controller whose zones to start.
@@ -193,7 +193,7 @@ class Hydrawise(HydrawiseBase):
         )
         await self._mutation(selector)
 
-    async def stop_all_zones(self, controller: Controller):
+    async def stop_all_zones(self, controller: Controller) -> None:
         """Stops all zones attached to a controller.
 
         :param controller: The controller whose zones to stop.
@@ -205,7 +205,7 @@ class Hydrawise(HydrawiseBase):
         )
         await self._mutation(selector)
 
-    async def suspend_zone(self, zone: Zone, until: datetime):
+    async def suspend_zone(self, zone: Zone, until: datetime) -> None:
         """Suspends a zone's schedule.
 
         :param zone: The zone to suspend.
@@ -219,7 +219,7 @@ class Hydrawise(HydrawiseBase):
         )
         await self._mutation(selector)
 
-    async def resume_zone(self, zone: Zone):
+    async def resume_zone(self, zone: Zone) -> None:
         """Resumes a zone's schedule.
 
         :param zone: The zone whose schedule to resume.
@@ -229,7 +229,7 @@ class Hydrawise(HydrawiseBase):
         )
         await self._mutation(selector)
 
-    async def suspend_all_zones(self, controller: Controller, until: datetime):
+    async def suspend_all_zones(self, controller: Controller, until: datetime) -> None:
         """Suspends the schedule of all zones attached to a given controller.
 
         :param controller: The controller whose zones to suspend.
@@ -243,7 +243,7 @@ class Hydrawise(HydrawiseBase):
         )
         await self._mutation(selector)
 
-    async def resume_all_zones(self, controller: Controller):
+    async def resume_all_zones(self, controller: Controller) -> None:
         """Resumes the schedule of all zones attached to the given controller.
 
         :param controller: The controller whose zones to resume.
@@ -255,7 +255,7 @@ class Hydrawise(HydrawiseBase):
         )
         await self._mutation(selector)
 
-    async def delete_zone_suspension(self, suspension: ZoneSuspension):
+    async def delete_zone_suspension(self, suspension: ZoneSuspension) -> None:
         """Removes a specific zone suspension.
 
         Useful when there are multiple suspensions for a zone in effect.

--- a/pydrawise/legacy.py
+++ b/pydrawise/legacy.py
@@ -184,7 +184,7 @@ class LegacyHydrawiseAsync(HydrawiseBase):
         zone: Zone,
         mark_run_as_scheduled: bool = False,
         custom_run_duration: int = 0,
-    ):
+    ) -> None:
         """Starts a zone's run cycle.
 
         :param zone: The zone to start.
@@ -202,7 +202,7 @@ class LegacyHydrawiseAsync(HydrawiseBase):
             params["custom"] = custom_run_duration
         await self._get("setzone.php", **params)
 
-    async def stop_zone(self, zone: Zone):
+    async def stop_zone(self, zone: Zone) -> None:
         """Stops a zone.
 
         :param zone: The zone to stop.
@@ -214,7 +214,7 @@ class LegacyHydrawiseAsync(HydrawiseBase):
         controller: Controller,
         mark_run_as_scheduled: bool = False,
         custom_run_duration: int = 0,
-    ):
+    ) -> None:
         """Starts all zones attached to a controller.
 
         :param controller: The controller whose zones to start.
@@ -232,7 +232,7 @@ class LegacyHydrawiseAsync(HydrawiseBase):
             params["custom"] = custom_run_duration
         await self._get("setzone.php", **params)
 
-    async def stop_all_zones(self, controller: Controller):
+    async def stop_all_zones(self, controller: Controller) -> None:
         """Stops all zones attached to a controller.
 
         :param controller: The controller whose zones to stop.
@@ -240,7 +240,7 @@ class LegacyHydrawiseAsync(HydrawiseBase):
         _ = controller  # unused
         await self._get("setzone.php", action="stopall")
 
-    async def suspend_zone(self, zone: Zone, until: datetime):
+    async def suspend_zone(self, zone: Zone, until: datetime) -> None:
         """Suspends a zone's schedule.
 
         :param zone: The zone to suspend.
@@ -254,14 +254,14 @@ class LegacyHydrawiseAsync(HydrawiseBase):
             custom=int(until.timestamp()),
         )
 
-    async def resume_zone(self, zone: Zone):
+    async def resume_zone(self, zone: Zone) -> None:
         """Resumes a zone's schedule.
 
         :param zone: The zone whose schedule to resume.
         """
         await self._get("setzone.php", action="suspend", relay_id=zone.id, period_id=0)
 
-    async def suspend_all_zones(self, controller: Controller, until: datetime):
+    async def suspend_all_zones(self, controller: Controller, until: datetime) -> None:
         """Suspends the schedule of all zones attached to a given controller.
 
         :param controller: The controller whose zones to suspend.
@@ -275,7 +275,7 @@ class LegacyHydrawiseAsync(HydrawiseBase):
             custom=int(until.timestamp()),
         )
 
-    async def resume_all_zones(self, controller: Controller):
+    async def resume_all_zones(self, controller: Controller) -> None:
         """Resumes the schedule of all zones attached to the given controller.
 
         :param controller: The controller whose zones to resume.
@@ -283,7 +283,7 @@ class LegacyHydrawiseAsync(HydrawiseBase):
         _ = controller  # unused
         await self._get("setzone.php", action="suspendall", period_id=0)
 
-    async def delete_zone_suspension(self, suspension: ZoneSuspension):
+    async def delete_zone_suspension(self, suspension: ZoneSuspension) -> None:
         """Removes a specific zone suspension.
 
         Useful when there are multiple suspensions for a zone in effect.

--- a/pydrawise/legacy.py
+++ b/pydrawise/legacy.py
@@ -7,7 +7,7 @@ import time
 
 import requests
 
-from ..exceptions import NotInitializedError, UnknownError
+from .exceptions import NotInitializedError, UnknownError
 
 _BASE_URL = "https://api.hydrawise.com/api/v1"
 _TIMEOUT = 10  # seconds

--- a/pydrawise/legacy.py
+++ b/pydrawise/legacy.py
@@ -3,14 +3,295 @@
 This library should remain compatible with https://github.com/ptcryan/hydrawiser.
  """
 
+from datetime import datetime, timedelta
 import time
 
+import aiohttp
 import requests
 
+from .base import HydrawiseBase
 from .exceptions import NotInitializedError, UnknownError
+from .schema import (
+    Controller,
+    ControllerHardware,
+    ControllerModel,
+    PastZoneRuns,
+    RunStatus,
+    ScheduledZoneRun,
+    ScheduledZoneRuns,
+    StandardWateringSettings,
+    User,
+    Zone,
+    ZoneStatus,
+    ZoneSuspension,
+)
 
 _BASE_URL = "https://api.hydrawise.com/api/v1"
 _TIMEOUT = 10  # seconds
+
+
+class LegacyHydrawiseAsync(HydrawiseBase):
+    """Async client library for interacting with the Hydrawise v1 API.
+
+    This should remain compatible with client.Hydrawise.
+    """
+
+    def __init__(self, user_token: str) -> None:
+        self._api_key = user_token
+
+    async def _get(self, path: str, **kwargs) -> dict:
+        url = f"{_BASE_URL}/{path}"
+        params = {"api_key": self._api_key}
+        params.update(kwargs)
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, params=params, timeout=_TIMEOUT) as resp:
+                return await resp.json()
+
+    async def get_user(self) -> User:
+        """Retrieves the currently authenticated user.
+
+        :rtype: User
+        """
+        raise NotImplementedError
+
+    async def get_controllers(self) -> list[Controller]:
+        """Retrieves all controllers associated with the currently authenticated user.
+
+        :rtype: list[Controller]
+        """
+        resp_json = await self._get("customerdetails.php", type="controllers")
+        controllers = []
+        for controller_json in resp_json["controllers"]:
+            controllers.append(
+                Controller(
+                    id=controller_json["controller_id"],
+                    name=controller_json["name"],
+                    software_version="",
+                    hardware=ControllerHardware(
+                        serial_number=controller_json["serial_number"],
+                        version="",
+                        status="",
+                        model=ControllerModel(
+                            name="",
+                            description="",
+                        ),
+                        firmware=[],
+                    ),
+                    last_contact_time=datetime.fromtimestamp(
+                        controller_json["last_contact"]
+                    ),
+                    last_action="",
+                    online=True,
+                    sensors=[],
+                    zones=[],
+                    permitted_program_start_times=[],
+                    status=None,
+                )
+            )
+        return controllers
+
+    async def get_controller(self, controller_id: int) -> Controller:
+        """Retrieves a single controller by its unique identifier.
+
+        :param controller_id: Unique identifier for the controller to retrieve.
+        :rtype: Controller
+        """
+        _ = controller_id  # unused
+        raise NotImplementedError
+
+    async def get_zones(self, controller: Controller) -> list[Zone]:
+        """Retrieves zones associated with the given controller.
+
+        :param controller: Controller whose zones to fetch.
+        :rtype: list[Zone]
+        """
+        _ = controller  # unused
+        resp_json = await self._get("statusschedule.php")
+        zones = []
+        for zone_json in resp_json["relays"]:
+            current_run = None
+            next_run = None
+            if zone_json["time"] == 1:
+                # in progress
+                current_run = ScheduledZoneRun(
+                    id="",
+                    start_time=datetime.now(),
+                    end_time=datetime.now(),
+                    normal_duration=timedelta(minutes=0),
+                    duration=timedelta(minutes=0),
+                    remaining_time=timedelta(seconds=zone_json["run"]),
+                    status=RunStatus(value=0, label=""),
+                )
+            else:
+                start_time = datetime.now() + timedelta(seconds=zone_json["time"])
+                duration = timedelta(seconds=zone_json["run"])
+                next_run = ScheduledZoneRun(
+                    id="",
+                    start_time=start_time,
+                    end_time=start_time + duration,
+                    normal_duration=duration,
+                    duration=duration,
+                    remaining_time=timedelta(seconds=0),
+                    status=RunStatus(value=0, label=""),
+                )
+            suspended_until = None
+            if zone_json["time"] == 1576800000:
+                suspended_until = ZoneSuspension(
+                    id=0,
+                    start_time=datetime.now(),
+                    end_time=datetime.now() + timedelta(seconds=zone_json["time"]),
+                )
+            zones.append(
+                Zone(
+                    id=zone_json["relay_id"],
+                    number=zone_json["relay"],
+                    name=zone_json["name"],
+                    watering_settings=StandardWateringSettings(
+                        fixed_watering_adjustment=0,
+                        cycle_and_soak_settings=None,
+                        standard_program_applications=[],
+                    ),
+                    scheduled_runs=ScheduledZoneRuns(
+                        summary="",
+                        current_run=current_run,
+                        next_run=next_run,
+                        status="",
+                    ),
+                    past_runs=PastZoneRuns(
+                        last_run=None,
+                        runs=[],
+                    ),
+                    status=ZoneStatus(
+                        relative_water_balance=0,
+                        suspended_until=suspended_until,
+                    ),
+                    suspensions=[],
+                )
+            )
+        return zones
+
+    async def get_zone(self, zone_id: int) -> Zone:
+        """Retrieves a zone by its unique identifier.
+
+        :param zone_id: The zone's unique identifier.
+        :rtype: Zone
+        """
+        _ = zone_id  # unused
+        raise NotImplementedError
+
+    async def start_zone(
+        self,
+        zone: Zone,
+        mark_run_as_scheduled: bool = False,
+        custom_run_duration: int = 0,
+    ):
+        """Starts a zone's run cycle.
+
+        :param zone: The zone to start.
+        :param mark_run_as_scheduled: Whether to mark the zone as having run as scheduled.
+        :param custom_run_duration: Duration (in seconds) to run the zone. If not
+            specified (or zero), will run for its default configured time.
+        """
+        _ = mark_run_as_scheduled  # unused.
+        params = {
+            "action": "run",
+            "relay_id": zone.id,
+            "period_id": 999,
+        }
+        if custom_run_duration > 0:
+            params["custom"] = custom_run_duration
+        await self._get("setzone.php", **params)
+
+    async def stop_zone(self, zone: Zone):
+        """Stops a zone.
+
+        :param zone: The zone to stop.
+        """
+        await self._get("setzone.php", action="stop", relay_id=zone.id)
+
+    async def start_all_zones(
+        self,
+        controller: Controller,
+        mark_run_as_scheduled: bool = False,
+        custom_run_duration: int = 0,
+    ):
+        """Starts all zones attached to a controller.
+
+        :param controller: The controller whose zones to start.
+        :param mark_run_as_scheduled: Whether to mark the zones as having run as scheduled.
+        :param custom_run_duration: Duration (in seconds) to run the zones. If not
+            specified (or zero), will run for each zone's default configured time.
+        """
+        _ = controller  # unused
+        _ = mark_run_as_scheduled  # unused
+        params = {
+            "action": "runall",
+            "period_id": 999,
+        }
+        if custom_run_duration > 0:
+            params["custom"] = custom_run_duration
+        await self._get("setzone.php", **params)
+
+    async def stop_all_zones(self, controller: Controller):
+        """Stops all zones attached to a controller.
+
+        :param controller: The controller whose zones to stop.
+        """
+        _ = controller  # unused
+        await self._get("setzone.php", action="stopall")
+
+    async def suspend_zone(self, zone: Zone, until: datetime):
+        """Suspends a zone's schedule.
+
+        :param zone: The zone to suspend.
+        :param until: When the suspension should end.
+        """
+        await self._get(
+            "setzone.php",
+            action="suspend",
+            relay_id=zone.id,
+            period_id=999,
+            custom=int(until.timestamp()),
+        )
+
+    async def resume_zone(self, zone: Zone):
+        """Resumes a zone's schedule.
+
+        :param zone: The zone whose schedule to resume.
+        """
+        await self._get("setzone.php", action="suspend", relay_id=zone.id, period_id=0)
+
+    async def suspend_all_zones(self, controller: Controller, until: datetime):
+        """Suspends the schedule of all zones attached to a given controller.
+
+        :param controller: The controller whose zones to suspend.
+        :param until: When the suspension should end.
+        """
+        _ = controller  # unused
+        await self._get(
+            "setzone.php",
+            action="suspendall",
+            period_id=999,
+            custom=int(until.timestamp()),
+        )
+
+    async def resume_all_zones(self, controller: Controller):
+        """Resumes the schedule of all zones attached to the given controller.
+
+        :param controller: The controller whose zones to resume.
+        """
+        _ = controller  # unused
+        await self._get("setzone.php", action="suspendall", period_id=0)
+
+    async def delete_zone_suspension(self, suspension: ZoneSuspension):
+        """Removes a specific zone suspension.
+
+        Useful when there are multiple suspensions for a zone in effect.
+
+        :param suspension: The suspension to delete.
+        """
+        _ = suspension  # unused
+        raise NotImplementedError
 
 
 class LegacyHydrawise:


### PR DESCRIPTION
This new client has the same interface as the V2 GraphQL client, and they now both inherit from the same ABC.

Having the same interface will make migration of the HA integration to the V2 API much simpler.