### PR TITLE
Fetch more fields automatically

### DIFF
--- a/pydrawise/client.py
+++ b/pydrawise/client.py
@@ -82,7 +82,9 @@ class Hydrawise(HydrawiseBase):
         :rtype: User
         """
         skip = [] if fetch_zones else ["controllers.zones"]
-        selector = self._schema.Query.me.select(*get_selectors(self._schema, User, skip))
+        selector = self._schema.Query.me.select(
+            *get_selectors(self._schema, User, skip)
+        )
         result = await self._query(selector)
         return deserialize(User, result["me"])
 

--- a/pydrawise/client.py
+++ b/pydrawise/client.py
@@ -81,7 +81,8 @@ class Hydrawise(HydrawiseBase):
         :param fetch_zones: Not used in this implementation.
         :rtype: User
         """
-        selector = self._schema.Query.me.select(*get_selectors(self._schema, User))
+        skip = [] if fetch_zones else ["controllers.zones"]
+        selector = self._schema.Query.me.select(*get_selectors(self._schema, User, skip))
         result = await self._query(selector)
         return deserialize(User, result["me"])
 

--- a/pydrawise/schema.py
+++ b/pydrawise/schema.py
@@ -9,7 +9,7 @@ from enum import Enum, auto
 from typing import Optional, Union
 
 from apischema.conversions import Conversion
-from apischema.metadata import conversion, skip
+from apischema.metadata import conversion
 
 # The names in this file are from the GraphQL schema and don't always adhere to
 # the naming scheme that pylint expects.
@@ -406,7 +406,7 @@ class Controller:
     )
     online: bool = False
     sensors: list[Sensor] = field(default_factory=list)
-    zones: list[Zone] = field(default_factory=list, metadata=skip(deserialization=True))
+    zones: list[Zone] = field(default_factory=list)
     permitted_program_start_times: list[ProgramStartTime] = field(default_factory=list)
     status: Optional[ControllerStatus] = None
 
@@ -419,9 +419,7 @@ class User:
     customer_id: int = 0
     name: str = ""
     email: str = ""
-    controllers: list[Controller] = field(
-        default_factory=list, metadata=skip(deserialization=True)
-    )
+    controllers: list[Controller] = field(default_factory=list)
 
 
 class Query(ABC):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -118,7 +118,7 @@ async def test_get_user(api: Hydrawise, mock_session, controller_json, zone_json
             "customerId": 1,
             "name": "My Name",
             "email": "me@asdf.com",
-            "controllers": [controller_json]
+            "controllers": [controller_json],
         }
     }
     user = await api.get_user()
@@ -141,7 +141,7 @@ async def test_get_user_no_zones(api: Hydrawise, mock_session, controller_json):
             "customerId": 1,
             "name": "My Name",
             "email": "me@asdf.com",
-            "controllers": [controller_json]
+            "controllers": [controller_json],
         }
     }
     user = await api.get_user(fetch_zones=False)

--- a/tests/test_schema_utils.py
+++ b/tests/test_schema_utils.py
@@ -1,0 +1,7 @@
+from pydrawise import schema_utils
+
+
+def test_parse_skip():
+    skip = ["a", "b.c", "b.d", "e.f.g"]
+    want = ["a"], {"b": ["c", "d"], "e": ["f.g"]}
+    assert schema_utils.parse_skip(skip) == want


### PR DESCRIPTION
* Make `get_user()` also return controllers.
* Respect the `fetch_zones` parameter added for the legacy client
* Make `get_controller()` and `get_controllers()` also return zones

This reduces the number of RPCs necessary for populating data in Home Assistant.