### PR TITLE
Drop gql aiohttp extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description     = "Python API for interacting with Hydrawise sprinkler controlle
 authors         = [
     {name = "David Knowles", email = "dknowles2@gmail.com"},
 ]
-dependencies    = ["aiohttp ", "apischema", "gql[aiohttp]", "graphql-core", "requests"]
+dependencies    = ["aiohttp ", "apischema", "gql", "graphql-core", "requests"]
 requires-python = ">=3.10"
 dynamic         = ["readme", "version"]
 license         = {text = "Apache License 2.0"}

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,7 +2,7 @@ aiohttp==3.8.5
 aioresponses==0.7.4
 apischema==0.18.0
 freezegun==1.2.2
-gql[aiohttp]==3.4.1
+gql==3.4.1
 graphql-core==3.2.3
 pytest==7.4.2
 pytest-asyncio==0.21.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp==3.8.5
 apischema==0.18.0
-gql[aiohttp]==3.4.1
+gql==3.4.1
 graphql-core==3.2.3
 requests==2.31.0


### PR DESCRIPTION
Drop the `gql[aiohttp]` extra.

**Background**
`gql 3.4.1` pins `aiohttp<3.9`. This isn't an issue now as the current version is `3.8.5`. However `3.9.0` is expected to be released this weekend with support for Python 3.12. Thus the pin in `gql` would ultimately block the `aiohttp` update in Home Assistant.

https://github.com/graphql-python/gql/blob/v3.4.1/setup.py#L41

I've already contributed a patch upstream. Unfortunately though the release of `gql` is blocked currently. Thus the best option to address it is by removing the extra requirement here. `aiohttp` still is an explicit dependency, so there shouldn't be any issues.

- https://github.com/graphql-python/gql/pull/425
- https://github.com/graphql-python/gql/issues/427