### PR TITLE
Fix watering report bug

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -254,12 +254,12 @@ def watering_report_json():
                     "standardProgram": None,
                     "advancedProgram": {"id": 4729362, "name": ""},
                     "reportedStartTime": {
-                        "value": "Fri, 01 Dec 23 04:19:59 -0800",
-                        "timestamp": 1701433199,
+                        "value": "Fri, 01 Nov 23 04:19:59 -0800",
+                        "timestamp": 1698797999,
                     },
                     "reportedEndTime": {
-                        "value": "Fri, 01 Dec 23 04:39:59 -0800",
-                        "timestamp": 1701434399,
+                        "value": "Fri, 01 Nov 23 04:39:59 -0800",
+                        "timestamp": 1698799199,
                     },
                     "reportedDuration": 1200,
                     "reportedStatus": {
@@ -544,3 +544,4 @@ async def test_get_watering_report(
     query = print_ast(selector)
     assert "reports" in query
     assert "watering" in query
+    assert len(report) == 1


### PR DESCRIPTION
The call to the `watering()` GraphQL method can sometimes return report entries that are outside of the provided start and end time. This PR adds code to filter out all entries that happen before the provided start time or after the provided end time.