### PR TITLE
Don't set next_run when a zone is suspended

### DIFF
--- a/pydrawise/legacy.py
+++ b/pydrawise/legacy.py
@@ -231,23 +231,22 @@ def _controller_from_json(controller_json: dict) -> Controller:
 def _zone_from_json(zone_json: dict) -> Zone:
     current_run = None
     next_run = None
+    suspended_until = None
     if zone_json["time"] == 1:
         current_run = ScheduledZoneRun(
             remaining_time=timedelta(seconds=zone_json["run"]),
         )
+    elif zone_json["time"] == 1576800000:
+        suspended_until = ZoneSuspension(end_time=datetime.max)
     else:
-        start_time = datetime.now() + timedelta(seconds=zone_json["time"])
+        now = datetime.now().replace(microsecond=0)
+        start_time = now + timedelta(seconds=zone_json["time"])
         duration = timedelta(seconds=zone_json["run"])
         next_run = ScheduledZoneRun(
             start_time=start_time,
             end_time=start_time + duration,
             normal_duration=duration,
             duration=duration,
-        )
-    suspended_until = None
-    if zone_json["time"] == 1576800000:
-        suspended_until = ZoneSuspension(
-            end_time=datetime.now() + timedelta(seconds=zone_json["time"]),
         )
     return Zone(
         id=zone_json["relay_id"],

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -320,9 +320,8 @@ class TestLegacyHydrawiseAsync:
                 assert zones[2].name == "Rotary - Front"
                 assert zones[2].number == 3
                 assert zones[2].scheduled_runs.current_run is None
-                assert zones[2].status.suspended_until.end_time == datetime(
-                    2072, 12, 19, 1, 0
-                )
+                assert zones[2].scheduled_runs.next_run is None
+                assert zones[2].status.suspended_until.end_time == datetime.max
 
     async def test_start_zone(self, success_status: dict) -> None:
         """Test the start_zone method."""


### PR DESCRIPTION
This is one of the problems with https://github.com/home-assistant/core/issues/110054

If a zone is suspended, the `time` attribute returned is a constant of 50 years. This means that every time we refreshed the data, we got a moving value for the next run based on the delta from the current time at data refresh.

Instead of doing this, we just set `next_run` to `None` to indicate that we don't know when the next run will occur.

To fix a similar issue, we also clear out the `microsecond` value of the `now` datetime to make sure we don't drift slightly since the API only returns second-precision times.

Lastly, since we don't know the absolute time at which the suspension will end, we instead just set `suspended_until` to `datetime.max`, which also prevents date drifts from happening.