### PR TITLE
Report total watering time as part of the water use summary

### DIFF
--- a/pydrawise/client.py
+++ b/pydrawise/client.py
@@ -1,6 +1,6 @@
 """Client library for interacting with Hydrawise's cloud API."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from functools import cache
 from importlib import resources
 import logging
@@ -428,11 +428,17 @@ class Hydrawise(HydrawiseBase):
                 and entry.run_event.reported_water_usage is not None
             ):
                 active_use = entry.run_event.reported_water_usage.value
+                active_time = entry.run_event.reported_duration
                 if summary.unit == "":
                     summary.unit = entry.run_event.reported_water_usage.unit
                 summary.total_active_use += active_use
+                summary.total_active_time += active_time
                 summary.active_use_by_zone_id.setdefault(entry.run_event.zone.id, 0)
                 summary.active_use_by_zone_id[entry.run_event.zone.id] += active_use
+                summary.active_time_by_zone_id.setdefault(
+                    entry.run_event.zone.id, timedelta()
+                )
+                summary.active_time_by_zone_id[entry.run_event.zone.id] += active_time
 
         # total active and inactive water use
         for sensor in result["controller"]["sensors"]:

--- a/pydrawise/client.py
+++ b/pydrawise/client.py
@@ -4,7 +4,6 @@ from datetime import datetime, timedelta
 from functools import cache
 from importlib import resources
 import logging
-from typing import cast
 
 from gql import Client
 from gql.dsl import DSLField, DSLMutation, DSLQuery, DSLSchema, DSLSelectable, dsl_gql

--- a/pydrawise/client.py
+++ b/pydrawise/client.py
@@ -437,6 +437,8 @@ class Hydrawise(HydrawiseBase):
         # total active water use and time
         summary = ControllerWaterUseSummary()
         total_active_use = 0.0
+        total_use = 0.0
+        total_inactive_use = 0.0
         for entry in entries:
             if entry.run_event is None or entry.run_event.zone is None:
                 continue
@@ -460,8 +462,6 @@ class Hydrawise(HydrawiseBase):
             return summary
 
         # total inactive water use
-        total_use = 0.0
-        total_inactive_use = 0.0
         for sensor_json in result["controller"]["sensors"]:
             sensor = deserialize(SensorWithFlowSummary, sensor_json)
             if (

--- a/pydrawise/schema.py
+++ b/pydrawise/schema.py
@@ -525,6 +525,16 @@ class Sensor:
 
 
 @dataclass
+@type_name("Sensor")
+class SensorWithFlowSummary(Sensor):
+    """A Sensor, as returned by its `flowSummary` method."""
+
+    flow_summary: Optional[SensorFlowSummary] = _optional_field(
+        default_factory=SensorFlowSummary
+    )
+
+
+@dataclass
 class _WaterTime:
     """A water time duration."""
 
@@ -672,12 +682,12 @@ class ControllerWaterUseSummary:
 
     _pydrawise_type = True
 
-    total_use: float = 0.0
-    total_active_use: float = 0.0
-    total_inactive_use: float = 0.0
     total_active_time: timedelta = field(
         metadata=_duration_conversion("seconds"), default=timedelta()
     )
-    active_use_by_zone_id: dict[int, float] = field(default_factory=dict)
     active_time_by_zone_id: dict[int, timedelta] = field(default_factory=dict)
-    unit: str = ""
+    total_use: Optional[float] = None
+    total_active_use: Optional[float] = None
+    total_inactive_use: Optional[float] = None
+    active_use_by_zone_id: dict[int, float] = field(default_factory=dict)
+    unit: Optional[str] = None

--- a/pydrawise/schema.py
+++ b/pydrawise/schema.py
@@ -665,7 +665,9 @@ class ControllerWaterUseSummary:
 
     Active use means water use during a scheduled or manual zone run.
     Inactive use means water use when no zone was actively running. This can happen when
-    faucets (i.e., garden hoses) are installed downstream of the flow meter.
+    faucets (i.e., garden hoses) are installed downstream of the flow meter. Water use
+    is only reported in the presence of a flow sensor. Active watering time is always
+    reported.
     """
 
     _pydrawise_type = True

--- a/pydrawise/schema.py
+++ b/pydrawise/schema.py
@@ -673,5 +673,9 @@ class ControllerWaterUseSummary:
     total_use: float = 0.0
     total_active_use: float = 0.0
     total_inactive_use: float = 0.0
+    total_active_time: timedelta = field(
+        metadata=_duration_conversion("seconds"), default=timedelta()
+    )
     active_use_by_zone_id: dict[int, float] = field(default_factory=dict)
+    active_time_by_zone_id: dict[int, timedelta] = field(default_factory=dict)
     unit: str = ""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -620,6 +620,6 @@ async def test_get_water_use_summary_without_sensor(
     assert "watering" in query
     assert 5955343 not in summary.active_use_by_zone_id
     assert summary.active_time_by_zone_id[5955343] == timedelta(seconds=1200)
-    assert summary.total_active_use == 0.0
-    assert summary.total_inactive_use == 0.0
+    assert summary.total_active_use == None
+    assert summary.total_inactive_use == None
     assert summary.total_active_time == timedelta(seconds=1200)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -581,8 +581,10 @@ async def test_get_water_use_summary(
     assert "watering" in query
     assert "flowSummary(" in query
     assert summary.active_use_by_zone_id[5955343] == 34.000263855044786
+    assert summary.active_time_by_zone_id[5955343] == timedelta(seconds=1200)
     assert summary.total_active_use == 34.000263855044786
     assert summary.total_inactive_use == (
         23100.679266065246 if flow_summary_json else 0.0
     )
+    assert summary.total_active_time == timedelta(seconds=1200)
     assert summary.unit == "gal"


### PR DESCRIPTION
Report total watering time as part of the water use summary. Right now, we only report remaining watering time during an active watering cycle. 

Refactored the code to allow fetching the water use summary even in the absence of a flow sensor. In this case, we only report the total watering time. The total water use will be zero. The allows us to expose the daily total watering time in HA even for folks that don't own a flow sensor.

