### PR TITLE
Fix type of timeout param for aiohttp bump

### DIFF
--- a/pydrawise/legacy.py
+++ b/pydrawise/legacy.py
@@ -1,7 +1,7 @@
-""""API for interacting with Hydrawise sprinkler controllers.
+"""API for interacting with Hydrawise sprinkler controllers.
 
 This library should remain compatible with https://github.com/ptcryan/hydrawiser.
- """
+"""
 
 from datetime import datetime, timedelta
 import time
@@ -41,7 +41,9 @@ class LegacyHydrawiseAsync(HydrawiseBase):
         params = {"api_key": self._api_key}
         params.update(kwargs)
         async with aiohttp.ClientSession() as session:
-            async with session.get(url, params=params, timeout=_TIMEOUT) as resp:
+            async with session.get(
+                url, params=params, timeout=aiohttp.ClientTimeout(total=_TIMEOUT)
+            ) as resp:
                 resp.raise_for_status()
                 return await resp.json()
 

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 import re
 from unittest import mock
 
+from aiohttp import ClientTimeout
 from aioresponses import aioresponses
 from freezegun import freeze_time
 from pytest import fixture
@@ -343,7 +344,7 @@ class TestLegacyHydrawiseAsync:
                     "relay_id": 12345,
                     "period_id": 999,
                 },
-                timeout=10,
+                timeout=ClientTimeout(total=10),
             )
 
     async def test_stop_zone(self, success_status: dict) -> None:
@@ -361,7 +362,7 @@ class TestLegacyHydrawiseAsync:
             m.assert_called_once_with(
                 "https://api.hydrawise.com/api/v1/setzone.php",
                 params={"api_key": API_KEY, "action": "stop", "relay_id": 12345},
-                timeout=10,
+                timeout=ClientTimeout(total=10),
             )
 
     async def test_start_all_zones(self, success_status: dict) -> None:
@@ -382,7 +383,7 @@ class TestLegacyHydrawiseAsync:
                     "period_id": 999,
                     "controller_id": 1111,
                 },
-                timeout=10,
+                timeout=ClientTimeout(total=10),
             )
 
     async def test_stop_all_zones(self, success_status: dict) -> None:
@@ -398,7 +399,7 @@ class TestLegacyHydrawiseAsync:
             m.assert_called_once_with(
                 "https://api.hydrawise.com/api/v1/setzone.php",
                 params={"api_key": API_KEY, "action": "stopall", "controller_id": 1111},
-                timeout=10,
+                timeout=ClientTimeout(total=10),
             )
 
     async def test_suspend_zone(self, success_status: dict) -> None:
@@ -422,7 +423,7 @@ class TestLegacyHydrawiseAsync:
                     "period_id": 999,
                     "custom": 1672621200,
                 },
-                timeout=10,
+                timeout=ClientTimeout(total=10),
             )
 
     async def test_resume_zone(self, success_status: dict) -> None:
@@ -445,7 +446,7 @@ class TestLegacyHydrawiseAsync:
                     "relay_id": 12345,
                     "period_id": 0,
                 },
-                timeout=10,
+                timeout=ClientTimeout(total=10),
             )
 
     async def test_suspend_all_zones(self, success_status: dict) -> None:
@@ -469,7 +470,7 @@ class TestLegacyHydrawiseAsync:
                     "custom": 1672621200,
                     "controller_id": 1111,
                 },
-                timeout=10,
+                timeout=ClientTimeout(total=10),
             )
 
     async def test_resume_all_zones(self, success_status: dict) -> None:
@@ -490,7 +491,7 @@ class TestLegacyHydrawiseAsync:
                     "period_id": 0,
                     "controller_id": 1111,
                 },
-                timeout=10,
+                timeout=ClientTimeout(total=10),
             )
 
 


### PR DESCRIPTION
Fixes mypy error:

```
pydrawise/legacy.py:44: error: Argument "timeout" to "get" of "ClientSession" has incompatible type "int"; expected "ClientTimeout | _SENTINEL | None"  [arg-type]
```

See: https://github.com/dknowles2/pydrawise/actions/runs/10312883535/job/28548801113?pr=181