### PR TITLE
Cache get_selectors() to prevent repeated DSLField/AST node creation

### DIFF
--- a/pydrawise/schema_utils.py
+++ b/pydrawise/schema_utils.py
@@ -107,7 +107,7 @@ def _get_selectors_cached(
             [f_type] = f.types
             if is_dataclass(f_type):
                 f_skip = tuple(skip_later.get(f.name, []))
-                ret.append(dsl_field.select(*_get_selectors_cached(f_type, f_skip)))
+                ret.append(dsl_field.select(*_get_selectors_cached(f_type, f_skip)))  # type: ignore[arg-type]
             else:
                 ret.append(dsl_field)
         else:
@@ -119,7 +119,7 @@ def _get_selectors_cached(
                 sel_args.append(
                     DSLInlineFragment()
                     .on(getattr(DSL_SCHEMA, get_type_name(f_type).graphql))  # type: ignore[arg-type]
-                    .select(*_get_selectors_cached(f_type, ()))
+                    .select(*_get_selectors_cached(f_type, ()))  # type: ignore[arg-type]
                 )
             ret.append(dsl_field.select(*sel_args))
     return tuple(ret)

--- a/pydrawise/schema_utils.py
+++ b/pydrawise/schema_utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections import namedtuple
 from dataclasses import fields, is_dataclass
+from functools import lru_cache
 from typing import (
     TYPE_CHECKING,
     Iterator,
@@ -87,23 +88,26 @@ def _fields(
         yield _Field(f.name, [field_type])
 
 
-def get_selectors(
-    cls: DataclassInstance | type[DataclassInstance],
-    skip_fields: list[str] | None = None,
-) -> list[DSLField]:
-    """Constructs GraphQL selectors for the given dataclass.
+@lru_cache(maxsize=None)
+def _get_selectors_cached(
+    cls: type,
+    skip_fields: tuple[str, ...],
+) -> tuple[DSLField, ...]:
+    """Cached implementation of get_selectors.
+
+    Uses a tuple for skip_fields to allow LRU caching with hashable arguments.
 
     :meta private:
     """
     ret = []
-    skip_now, skip_later = parse_skip(skip_fields or [])
+    skip_now, skip_later = parse_skip(list(skip_fields))
     for f in _fields(cls, skip_now):
         dsl_field = getattr(getattr(DSL_SCHEMA, get_type_name(cls).graphql), f.name)  # type: ignore[arg-type]
         if len(f.types) == 1:
             [f_type] = f.types
             if is_dataclass(f_type):
-                f_skip = skip_later.get(f.name, [])
-                ret.append(getattr(dsl_field, "select")(*get_selectors(f_type, f_skip)))
+                f_skip = tuple(skip_later.get(f.name, []))
+                ret.append(dsl_field.select(*_get_selectors_cached(f_type, f_skip)))
             else:
                 ret.append(dsl_field)
         else:
@@ -115,10 +119,21 @@ def get_selectors(
                 sel_args.append(
                     DSLInlineFragment()
                     .on(getattr(DSL_SCHEMA, get_type_name(f_type).graphql))  # type: ignore[arg-type]
-                    .select(*get_selectors(f_type))
+                    .select(*_get_selectors_cached(f_type, ()))
                 )
-            ret.append(getattr(dsl_field, "select")(*sel_args))
-    return ret
+            ret.append(dsl_field.select(*sel_args))
+    return tuple(ret)
+
+
+def get_selectors(
+    cls: DataclassInstance | type[DataclassInstance],
+    skip_fields: list[str] | None = None,
+) -> list[DSLField]:
+    """Constructs GraphQL selectors for the given dataclass.
+
+    :meta private:
+    """
+    return list(_get_selectors_cached(cls, tuple(skip_fields or [])))
 
 
 def parse_skip(skip: list[str] | None = None) -> tuple[list[str], dict[str, list[str]]]:

--- a/pydrawise/schema_utils.py
+++ b/pydrawise/schema_utils.py
@@ -90,7 +90,7 @@ def _fields(
 
 @lru_cache(maxsize=None)
 def _get_selectors_cached(
-    cls: type,
+    cls: type[DataclassInstance],
     skip_fields: tuple[str, ...],
 ) -> tuple[DSLField, ...]:
     """Cached implementation of get_selectors.
@@ -133,7 +133,8 @@ def get_selectors(
 
     :meta private:
     """
-    return list(_get_selectors_cached(cls, tuple(skip_fields or [])))
+    cls_type = cls if isinstance(cls, type) else type(cls)
+    return list(_get_selectors_cached(cls_type, tuple(skip_fields or [])))
 
 
 def parse_skip(skip: list[str] | None = None) -> tuple[list[str], dict[str, list[str]]]:


### PR DESCRIPTION
## Summary

- `get_selectors()` was called on every API query without caching, causing the entire dataclass hierarchy to be traversed and new `DSLField` objects (and their nested `FieldNode`/`NameNode` AST sub-trees) to be rebuilt on every poll cycle.
- Over time this caused accumulation of GraphQL AST objects (`NameNode`, `FieldNode`, `SelectionSetNode`) that were slow to garbage collect, contributing to a memory leak in the Home Assistant Hydrawise integration (reported in [home-assistant/core#166930](https://github.com/home-assistant/core/issues/166930)).
- Extract a private `_get_selectors_cached()` decorated with `@lru_cache`. The public `get_selectors()` converts `skip_fields: list[str]` → `tuple[str, ...]` (to make it hashable) and delegates to the cached version.
- On cache hits, the cached `DSLField` objects — including their pre-built `selection_set` sub-trees — are returned directly. Nested `FieldNode`/`NameNode` AST nodes for sub-fields are reused rather than recreated on each query.
- The unique `(cls, skip_fields)` combinations are a small finite set (~20–30), so cache memory footprint is negligible.

## Test plan

- [ ] Existing tests pass (`test_schema_utils.py`, `test_client.py`)
- [ ] Manually verify that repeated calls to `get_selectors(Zone)` return the same `DSLField` objects (`assert get_selectors(Zone) is not get_selectors(Zone)` fails — they return equal lists wrapping the same cached tuple)

🤖 Generated with [Claude Code](https://claude.com/claude-code)