### PR TITLE
Skip past_runs by default in all zone-fetching queries

### DIFF
--- a/pydrawise/client.py
+++ b/pydrawise/client.py
@@ -117,6 +117,8 @@ class Hydrawise(HydrawiseBase):
         :rtype: User
         """
         skip = [] if fetch_zones else ["controllers.zones"]
+        if fetch_zones:
+            skip.append("controllers.zones.past_runs")
         result = await self._query(
             DSL_SCHEMA.Query.me.select(*get_selectors(User, skip))
         )
@@ -134,6 +136,8 @@ class Hydrawise(HydrawiseBase):
         skip = []
         if not fetch_zones:
             skip.append("zones")
+        else:
+            skip.append("zones.past_runs")
         if not fetch_sensors:
             skip.append("sensors")
 
@@ -152,7 +156,7 @@ class Hydrawise(HydrawiseBase):
         """
         result = await self._query(
             DSL_SCHEMA.Query.controller(controllerId=controller_id).select(
-                *get_selectors(Controller),
+                *get_selectors(Controller, ["zones.past_runs"]),
             )
         )
         return deserialize(Controller, result["controller"])
@@ -165,7 +169,7 @@ class Hydrawise(HydrawiseBase):
         """
         result = await self._query(
             DSL_SCHEMA.Query.controller(controllerId=controller.id).select(
-                DSL_SCHEMA.Controller.zones.select(*get_selectors(Zone)),
+                DSL_SCHEMA.Controller.zones.select(*get_selectors(Zone, ["past_runs"])),
             )
         )
         return deserialize(list[Zone], result["controller"]["zones"])
@@ -177,7 +181,7 @@ class Hydrawise(HydrawiseBase):
         :rtype: Zone
         """
         result = await self._query(
-            DSL_SCHEMA.Query.zone(zoneId=zone_id).select(*get_selectors(Zone))
+            DSL_SCHEMA.Query.zone(zoneId=zone_id).select(*get_selectors(Zone, ["past_runs"]))
         )
         return deserialize(Zone, result["zone"])
 


### PR DESCRIPTION
## Summary

- `Zone.past_runs` holds a `list[ScheduledZoneRun]` of historical watering runs returned by the Hydrawise API, going back several days with no upper bound.
- No known clients use `past_runs` during normal polling — it is fetched on every `get_zones()` call purely as a side effect of `get_selectors(Zone)` selecting all Zone fields.
- Over time this causes unbounded memory growth as new `ScheduledZoneRun` objects accumulate inside the `HybridClient._zones` cache and are never evicted. This is one of the root causes of the memory leak reported in [home-assistant/core#166930](https://github.com/home-assistant/core/issues/166930).

Skip `past_runs` by default in every code path that selects Zone fields:
- `get_zones()` / `get_zone()`: `get_selectors(Zone, ["past_runs"])`
- `get_controller()`: `get_selectors(Controller, ["zones.past_runs"])`
- `get_controllers()`: `"zones.past_runs"` added to skip list when zones are fetched
- `get_user()`: `"controllers.zones.past_runs"` added to skip when `fetch_zones=True`

## Test plan

- [ ] Existing tests pass
- [ ] Verify that fetched `Zone` objects have `past_runs == PastZoneRuns()` (empty default) after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)