### PR TITLE
Suppress REST NotAuthorizedError for secondary controllers

### DIFF
--- a/pydrawise/hybrid.py
+++ b/pydrawise/hybrid.py
@@ -14,7 +14,7 @@ from .auth import HybridAuth
 from .base import HydrawiseBase
 from .client import Hydrawise
 from .const import DEFAULT_APP_ID
-from .exceptions import ThrottledError
+from .exceptions import NotAuthorizedError, ThrottledError
 from .schema import (
     Controller,
     ControllerWaterUseSummary,
@@ -200,10 +200,25 @@ class HybridClient(HydrawiseBase):
             )
             return
 
+        last_err: NotAuthorizedError | None = None
+        succeeded = 0
         for controller_id in controller_ids:
-            json = await self._auth.get(
-                "statusschedule.php", controller_id=controller_id
-            )
+            try:
+                json = await self._auth.get(
+                    "statusschedule.php", controller_id=controller_id
+                )
+            except NotAuthorizedError as e:
+                # The REST API key is only valid for one controller. For multi-controller
+                # setups, secondary controllers will return "API key not valid". We track
+                # success across iterations so that if at least one controller succeeds,
+                # failures on others are treated as expected and suppressed.
+                _LOGGER.debug(
+                    "REST update skipped for controller %s (likely secondary): %s",
+                    controller_id,
+                    e,
+                )
+                last_err = e
+                continue
             self._rest_throttle.mark()
             self._rest_throttle.epoch_interval = timedelta(seconds=json["nextpoll"])
             zones = []
@@ -216,6 +231,9 @@ class HybridClient(HydrawiseBase):
                     self._zones[zone_json["relay_id"]] = Zone.from_json(zone_json)
                 zones.append(self._zones[zone_json["relay_id"]])
             self._controllers[controller_id].zones = zones
+            succeeded += 1
+        if succeeded == 0 and last_err is not None:
+            raise last_err
 
     @throttle
     async def get_zone(self, zone_id: int) -> Zone:

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -5,10 +5,14 @@ from unittest.mock import call, create_autospec
 from freezegun import freeze_time
 from pytest import fixture
 
+import pytest
+
 from pydrawise.auth import HybridAuth
 from pydrawise.client import Hydrawise
+from pydrawise.exceptions import NotAuthorizedError
 from pydrawise.hybrid import HybridClient, Throttler
-from pydrawise.schema import Zone
+from pydrawise.schema import Controller, Zone
+from pydrawise.schema_utils import deserialize
 
 FROZEN_TIME = "2023-01-01 01:00:00"
 
@@ -313,3 +317,40 @@ async def test_get_sensors(api, hybrid_auth, mock_gql_client, controller, rain_s
         assert await api.get_sensors(controller) == [sensor]
         mock_gql_client.get_sensors.assert_not_awaited()
         hybrid_auth.get.assert_not_awaited()
+
+
+async def test_get_zones_secondary_controller_rest_error(
+    api, hybrid_auth, mock_gql_client, controller_json, zone, status_schedule
+):
+    """NotAuthorizedError on a secondary controller is suppressed if the primary succeeds."""
+    secondary_json = {**controller_json, "id": controller_json["id"] + 1, "name": "Secondary"}
+    primary = deserialize(Controller, controller_json)
+    secondary = deserialize(Controller, secondary_json)
+
+    with freeze_time(FROZEN_TIME):
+        # Deplete GQL tokens with two fetches so the third falls back to REST.
+        mock_gql_client.get_controllers.return_value = [deepcopy(primary), deepcopy(secondary)]
+        await api.get_controllers()
+        await api.get_controllers()
+
+        # Third fetch: primary succeeds via REST, secondary raises NotAuthorizedError.
+        hybrid_auth.get.side_effect = lambda path, **kw: (
+            status_schedule if kw.get("controller_id") == primary.id
+            else (_ for _ in ()).throw(NotAuthorizedError("API key not valid"))
+        )
+        controllers = await api.get_controllers()
+        assert len(controllers) == 2
+
+
+async def test_get_zones_all_controllers_rest_error(
+    api, hybrid_auth, mock_gql_client, controller, zone, status_schedule
+):
+    """NotAuthorizedError propagates when every controller fails the REST call."""
+    with freeze_time(FROZEN_TIME):
+        mock_gql_client.get_controllers.return_value = [deepcopy(controller)]
+        await api.get_controllers()
+        await api.get_controllers()
+
+        hybrid_auth.get.side_effect = NotAuthorizedError("API key not valid")
+        with pytest.raises(NotAuthorizedError):
+            await api.get_controllers()


### PR DESCRIPTION
## What changed

In `HybridClient._update_zones`, the REST call to `statusschedule.php` for each controller is now wrapped in a `try/except NotAuthorizedError`. Success is tracked across the iteration:

- If **at least one** controller succeeds, failures on others are suppressed with a `DEBUG` log (expected for secondary controllers whose IDs aren't associated with the API key).
- If **every** controller fails, the last error is re-raised so real auth failures still surface.

## Why

The Hydrawise REST API key is scoped to a single controller. In multi-controller setups, secondary controllers return HTTP 404 `"API key not valid"` on every REST poll. This was propagating as `NotAuthorizedError`, causing HA to mark all entities unavailable within minutes of startup.

Closes https://github.com/home-assistant/core/issues/169784  
Related: #458

## Tests

Two new tests in `test_hybrid.py`:
- `test_get_zones_secondary_controller_rest_error` — verifies that a `NotAuthorizedError` on a secondary controller is suppressed when the primary succeeds.
- `test_get_zones_all_controllers_rest_error` — verifies that the error propagates when every controller fails.