### PR TITLE
Ignore generated _version.py and uv.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,9 @@ dmypy.json
 
 # Debug scripts
 debug/
+
+# Generated version file
+pydrawise/_version.py
+
+# uv lock file
+uv.lock


### PR DESCRIPTION
Adds `pydrawise/_version.py` and `uv.lock` to `.gitignore`. Both are generated files that shouldn't be tracked:

- `_version.py` is produced by the build system at install time.
- `uv.lock` is a local lockfile generated by uv.