### PR TITLE
Fix HybridAuth.check() to also validate the REST API key

### DIFF
--- a/pydrawise/auth.py
+++ b/pydrawise/auth.py
@@ -134,4 +134,5 @@ class HybridAuth(Auth, RestAuth):
 
     async def check(self) -> bool:
         await super().check()
+        await self._check_api_token()
         return True

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,10 +1,12 @@
 from datetime import timedelta
 
+import pytest
 from aioresponses import aioresponses
 from freezegun import freeze_time
 from pytest import fixture
 
 from pydrawise import auth
+from pydrawise.exceptions import NotAuthorizedError
 
 
 @fixture
@@ -73,3 +75,29 @@ async def test_token(mock_token_fetch):
     a = auth.Auth("__username__", "__password__")
     token = await a.token()
     assert token == "bearer __access-token__"
+
+
+async def test_hybrid_auth_check_validates_rest_api_key(token_payload):
+    a = auth.HybridAuth("__username__", "__password__", "__api_key__")
+    with aioresponses() as m:
+        m.post(auth.TOKEN_URL, status=200, payload=token_payload)
+        m.get(
+            f"{auth.REST_URL}/customerdetails.php?api_key=__api_key__",
+            status=200,
+            payload={"customer_id": 123},
+        )
+        result = await a.check()
+    assert result is True
+
+
+async def test_hybrid_auth_check_raises_on_invalid_rest_api_key(token_payload):
+    a = auth.HybridAuth("__username__", "__password__", "__bad_key__")
+    with aioresponses() as m:
+        m.post(auth.TOKEN_URL, status=200, payload=token_payload)
+        m.get(
+            f"{auth.REST_URL}/customerdetails.php?api_key=__bad_key__",
+            status=404,
+            body="API key not valid",
+        )
+        with pytest.raises(NotAuthorizedError):
+            await a.check()


### PR DESCRIPTION
## What changed

`HybridAuth.check()` previously called only `super().check()`, which validates the GraphQL token but not the REST API key. This meant an invalid or transiently rejected REST API key would only surface during actual data fetches — resulting in an unhandled `NotAuthorizedError` traceback instead of a clean auth failure signal.

This PR adds a call to `_check_api_token()` inside `HybridAuth.check()` so that both credentials are validated together.

## Why

Reported in #458: Home Assistant logs a full unexpected traceback when the Hydrawise REST endpoint intermittently returns "API key not valid", because the error surfaces mid-refresh rather than being caught as a credential check failure. Validating the REST API key in `check()` gives Home Assistant (and other callers) an earlier, cleaner signal.

## Tests

Two new tests in `tests/test_auth.py`:
- `test_hybrid_auth_check_validates_rest_api_key` — verifies `check()` returns `True` when both credentials are valid
- `test_hybrid_auth_check_raises_on_invalid_rest_api_key` — verifies `check()` raises `NotAuthorizedError` when the REST API key is rejected

## Notes

The issue also requests Home Assistant coordinator changes (converting `NotAuthorizedError` to `UpdateFailed` for transient failures). That work belongs in the HA core repo. This PR addresses the pydrawise-side gap noted in the issue.

Closes #458