### PR TITLE
Commit uv.lock, enforce it in CI, and fix PyPI publish version bug

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
## Summary
- Commits `uv.lock` and enforces it stays in sync with `pyproject.toml` in CI
- Fixes the PyPI publish workflow: `actions/checkout` defaulted to a shallow clone, which prevented `setuptools_scm` from seeing git tags. This caused the publish job to build a bogus dev version (`0.1.dev1+g<sha>`) instead of the real release version, which PyPI rejected with a 400 Bad Request. Added `fetch-depth: 0` so the full history (and tags) are available.

## Test plan
- [ ] CI passes on this branch
- [ ] Next PyPI release run succeeds with the correct version string