### PR TITLE
Fix automatic watering switch continuously changing value

### DIFF
--- a/pydrawise/schema.py
+++ b/pydrawise/schema.py
@@ -443,13 +443,15 @@ class Zone(BaseZone):
     def update_with_json(self, zone_json: dict) -> None:
         current_run = None
         next_run = None
-        suspended_until = None
         if zone_json["time"] == 1:
+            # Zone is currently running; it cannot be suspended.
             current_run = ScheduledZoneRun(
                 remaining_time=timedelta(seconds=zone_json["run"]),
             )
+            self.status = ZoneStatus(suspended_until=None)
         elif zone_json["time"] == 1576800000 or zone_json.get("type") == 110:
-            suspended_until = datetime.max
+            # Zone is permanently suspended (REST API sentinel values).
+            self.status = ZoneStatus(suspended_until=datetime.max)
         else:
             start_time = _now() + timedelta(seconds=zone_json["time"])
             duration = timedelta(seconds=zone_json["run"])
@@ -459,11 +461,14 @@ class Zone(BaseZone):
                 normal_duration=duration,
                 duration=duration,
             )
+            # Do NOT overwrite self.status.suspended_until here. The REST API
+            # cannot represent non-permanent suspensions (e.g. those set via the
+            # GraphQL API), so leaving the existing value in place preserves any
+            # suspension that was established through the GraphQL API.
         self.scheduled_runs = ScheduledZoneRuns(
             current_run=current_run,
             next_run=next_run,
         )
-        self.status = ZoneStatus(suspended_until=suspended_until)
 
 
 @dataclass

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -249,6 +249,43 @@ async def test_get_zones(
         hybrid_auth.get.assert_not_awaited()
 
 
+async def test_get_zones_preserves_gql_suspension_across_rest_fallback(
+    api, hybrid_auth, mock_gql_client, controller, zone, status_schedule
+):
+    """Regression test for #493.
+
+    A zone suspended via the GraphQL API (with a specific end date, as opposed
+    to a permanent suspension) must stay suspended across a REST-fallback poll
+    that reports it as having a normal upcoming next run -- the REST API has
+    no way to represent a dated suspension, so it cannot be used to conclude
+    the zone is unsuspended.
+    """
+    with freeze_time(FROZEN_TIME):
+        suspended_until = zone.status.suspended_until
+        assert suspended_until is not None
+        assert suspended_until != datetime.max
+
+        # First and second fetches query the GraphQL API and report the zone
+        # as suspended until a specific date.
+        mock_gql_client.get_zones.return_value = [deepcopy(zone)]
+        assert await api.get_zones(controller) == [zone]
+        mock_gql_client.get_zones.reset_mock()
+        assert await api.get_zones(controller) == [zone]
+
+        # Third fetch: GraphQL is throttled, so we fall back to REST. Zone A's
+        # entry in the REST payload (relay_id 0x10A, matching `zone`) reports
+        # a normal scheduled next run, with no information about the
+        # GraphQL-managed suspension.
+        mock_gql_client.get_zones.reset_mock()
+        status_schedule["relays"] = [status_schedule["relays"][0]]
+        hybrid_auth.get.return_value = status_schedule
+        [zone2] = await api.get_zones(controller)
+        mock_gql_client.get_zones.assert_not_awaited()
+
+        # The suspension must survive the REST poll instead of being wiped.
+        assert zone2.status.suspended_until == suspended_until
+
+
 async def test_get_user_get_zones(
     api, hybrid_auth, mock_gql_client, user, status_schedule
 ):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,4 +1,5 @@
 from dataclasses import fields, is_dataclass
+from datetime import datetime
 from string import ascii_lowercase
 
 from apischema.metadata.keys import CONVERSION_METADATA, FALL_BACK_ON_DEFAULT_METADATA
@@ -8,6 +9,7 @@ from graphql import build_schema
 from graphql.type import GraphQLBoolean, GraphQLInt, GraphQLNonNull, GraphQLString
 
 from pydrawise import schema as _schema
+from pydrawise.schema import Zone, ZoneStatus
 from pydrawise.schema_utils import deserialize
 
 
@@ -187,3 +189,76 @@ def test_optional_fields():
             "controllers": [],
         },
     )
+
+
+def _zone(suspended_until):
+    zone = Zone(id=0x10A, number=1, name="Zone A")
+    zone.status = ZoneStatus(suspended_until=suspended_until)
+    return zone
+
+
+def _relay_json(time_, type_=1, run=1800):
+    """A REST API statusschedule.php 'relays' entry."""
+    return {
+        "name": "Zone A",
+        "period": 259200,
+        "relay": 1,
+        "relay_id": 0x10A,
+        "run": run,
+        "stop": 1,
+        "time": time_,
+        "timestr": "Sat",
+        "type": type_,
+    }
+
+
+def test_update_with_json_preserves_dated_suspension_with_scheduled_next_run():
+    """Regression test for #493.
+
+    The REST API can't represent a non-permanent (GraphQL-managed) suspension:
+    a suspended-until-a-date zone looks identical in the REST response to an
+    unsuspended one, since both report a normal upcoming next-run time. A REST
+    poll must not clobber the suspension in that case.
+    """
+    suspended_until = datetime(2026, 8, 1, 12, 0, 0)
+    zone = _zone(suspended_until)
+
+    zone.update_with_json(_relay_json(time_=5400))
+
+    assert zone.status.suspended_until == suspended_until
+    assert zone.scheduled_runs.current_run is None
+    assert zone.scheduled_runs.next_run is not None
+
+
+def test_update_with_json_leaves_unsuspended_zone_unsuspended():
+    zone = _zone(None)
+
+    zone.update_with_json(_relay_json(time_=5400))
+
+    assert zone.status.suspended_until is None
+
+
+def test_update_with_json_clears_suspension_for_running_zone():
+    """A zone that's actively running cannot be suspended."""
+    zone = _zone(datetime(2026, 8, 1, 12, 0, 0))
+
+    zone.update_with_json(_relay_json(time_=1, run=1788))
+
+    assert zone.status.suspended_until is None
+    assert zone.scheduled_runs.current_run is not None
+
+
+def test_update_with_json_sets_permanent_suspension_from_sentinel_time():
+    zone = _zone(None)
+
+    zone.update_with_json(_relay_json(time_=1576800000))
+
+    assert zone.status.suspended_until == datetime.max
+
+
+def test_update_with_json_sets_permanent_suspension_from_type_110():
+    zone = _zone(None)
+
+    zone.update_with_json(_relay_json(time_=339777, type_=110))
+
+    assert zone.status.suspended_until == datetime.max


### PR DESCRIPTION
## Problem

The 'automatic watering' switch in Home Assistant continuously toggled between on and off approximately every 10-20 minutes.

## Root Cause

`Zone.update_with_json()` (called during REST API polls in `HybridClient._update_zones()`) unconditionally reset `self.status.suspended_until = None` for any zone not permanently suspended. However, the REST API cannot represent non-permanent suspensions — a zone with a specific GQL-managed `suspended_until` date looks identical in the REST response to a fully unsuspended zone.

The cycle was:
1. GraphQL API fetches zone with `suspended_until` set → automatic watering switch = OFF
2. REST API poll occurs → `update_with_json` sets `suspended_until = None` → automatic watering switch = ON
3. Next GraphQL refresh → `suspended_until` restored → automatic watering switch = OFF
4. ...repeat

## Fix

Only update `self.status.suspended_until` in `update_with_json` when the REST API gives us unambiguous information:
- Zone is currently **running** → cannot be suspended, set `suspended_until = None`
- Zone has a **sentinel value** (time=1576800000 or type=110) → permanently suspended, set `suspended_until = datetime.max`

For all other cases (zone has a scheduled next run), preserve the existing `suspended_until` value so GraphQL-managed suspensions survive REST polls.

Fixes #493