### PR TITLE
fix: Accept optional aiohttp.ClientSession in Auth and Hydrawise classes

### DIFF
--- a/pydrawise/auth.py
+++ b/pydrawise/auth.py
@@ -30,16 +30,25 @@ class Token:
 class Auth(BaseAuth):
     """Authentication support for the Hydrawise GraphQL API."""
 
-    def __init__(self, username: str, password: str) -> None:
+    def __init__(
+        self,
+        username: str,
+        password: str,
+        session: aiohttp.ClientSession | None = None,
+    ) -> None:
         """Initializer.
 
         :param username: The username to use for authenticating with the Hydrawise service.
         :param password: The password to use for authenticating with the Hydrawise service.
+        :param session: Optional aiohttp ClientSession to use for requests. If not
+            provided, a new session will be created for each request. It is the
+            caller's responsibility to close any session that is passed in.
         """
         self.__username = username
         self.__password = password
         self._lock = Lock()
         self._token: Token | None = None
+        self._session = session
 
     async def _fetch_token_locked(self, refresh=False):
         data = {
@@ -55,7 +64,8 @@ class Auth(BaseAuth):
             data["scope"] = "all"
             data["username"] = self.__username
             data["password"] = self.__password
-        async with aiohttp.ClientSession() as session:
+
+        async def _do_fetch(session: aiohttp.ClientSession) -> None:
             async with session.post(
                 TOKEN_URL,
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
@@ -72,6 +82,12 @@ class Auth(BaseAuth):
                     type=resp_json["token_type"],
                     expires=datetime.now() + timedelta(seconds=resp_json["expires_in"]),
                 )
+
+        if self._session is not None:
+            await _do_fetch(self._session)
+        else:
+            async with aiohttp.ClientSession() as session:
+                await _do_fetch(session)
 
     async def check(self) -> bool:
         """Validates that the credentials are valid."""
@@ -99,21 +115,39 @@ class Auth(BaseAuth):
 class RestAuth(BaseAuth):
     """Authentication support for the Hydrawise REST API."""
 
-    def __init__(self, api_key: str) -> None:
-        """Initializer."""
+    def __init__(
+        self,
+        api_key: str,
+        session: aiohttp.ClientSession | None = None,
+    ) -> None:
+        """Initializer.
+
+        :param api_key: The API key to use for authenticating with the Hydrawise service.
+        :param session: Optional aiohttp ClientSession to use for requests. If not
+            provided, a new session will be created for each request. It is the
+            caller's responsibility to close any session that is passed in.
+        """
         self._api_key = api_key
+        self._session = session
 
     async def get(self, path: str, **kwargs) -> dict:
         """Perform an authenticated GET request and return the JSON response."""
         url = f"{REST_URL}/{path}"
         params = {"api_key": self._api_key}
         params.update(kwargs)
-        async with aiohttp.ClientSession() as session:
+
+        async def _do_get(session: aiohttp.ClientSession) -> dict:
             async with session.get(url, params=params, timeout=REQUEST_TIMEOUT) as resp:
                 if resp.status == 404 and await resp.text() == _INVALID_API_KEY:
                     raise NotAuthorizedError(_INVALID_API_KEY)
                 resp.raise_for_status()
                 return await resp.json()
+
+        if self._session is not None:
+            return await _do_get(self._session)
+        else:
+            async with aiohttp.ClientSession() as session:
+                return await _do_get(session)
 
     async def check(self) -> bool:
         """Validates that the credentials are valid."""
@@ -124,10 +158,24 @@ class RestAuth(BaseAuth):
 class HybridAuth(Auth, RestAuth):
     """Authentication support for the Hydrawise GraphQL & REST APIs."""
 
-    def __init__(self, username: str, password: str, api_key: str) -> None:
-        """Initializer."""
-        Auth.__init__(self, username, password)
-        RestAuth.__init__(self, api_key)
+    def __init__(
+        self,
+        username: str,
+        password: str,
+        api_key: str,
+        session: aiohttp.ClientSession | None = None,
+    ) -> None:
+        """Initializer.
+
+        :param username: The username to use for authenticating with the Hydrawise service.
+        :param password: The password to use for authenticating with the Hydrawise service.
+        :param api_key: The API key to use for authenticating with the Hydrawise REST API.
+        :param session: Optional aiohttp ClientSession to use for requests. If not
+            provided, a new session will be created for each request. It is the
+            caller's responsibility to close any session that is passed in.
+        """
+        Auth.__init__(self, username, password, session=session)
+        RestAuth.__init__(self, api_key, session=session)
 
     async def _check_api_token(self):
         await self.get("customerdetails.php")

--- a/pydrawise/client.py
+++ b/pydrawise/client.py
@@ -1,6 +1,7 @@
 """Asynchronous client library for interacting with Hydrawise's GraphQL API."""
 
 import logging
+import aiohttp
 from datetime import datetime, timedelta
 
 from gql import Client
@@ -72,18 +73,29 @@ class Hydrawise(HydrawiseBase):
     Should be instantiated with an Auth object that handles authentication and low-level transport.
     """
 
-    def __init__(self, auth: Auth, app_id: str = DEFAULT_APP_ID) -> None:
+    def __init__(
+        self,
+        auth: Auth,
+        app_id: str = DEFAULT_APP_ID,
+        session: aiohttp.ClientSession | None = None,
+    ) -> None:
         """Initializes the client.
 
         :param auth: Handles authentication and transport.
         :param app_id: Unique identifier for the application accessing the Hydrawise API.
+        :param session: Optional aiohttp ClientSession to use for requests. If not
+            provided, a new session will be created for each request. It is the
+            caller's responsibility to close any session that is passed in.
         """
         self._auth = auth
         self._app_id = app_id
+        self._session = session
 
     async def _client(self) -> Client:
         headers = {"Authorization": await self._auth.token()}
-        transport = AIOHTTPTransport(url=GRAPHQL_URL, headers=headers)
+        transport = AIOHTTPTransport(
+            url=GRAPHQL_URL, headers=headers, client_session=self._session
+        )
         return Client(transport=transport, parse_results=True)
 
     async def _query(self, selector: DSLSelectable) -> dict:

--- a/pydrawise/hybrid.py
+++ b/pydrawise/hybrid.py
@@ -6,7 +6,7 @@ This utilizes both the GraphQL and REST APIs.
 import logging
 from asyncio import Lock
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
 from functools import wraps
 from typing import Awaitable, Callable, Coroutine, ParamSpec, TypeVar
 


### PR DESCRIPTION
Allows callers (e.g. Home Assistant) to pass in a shared `aiohttp.ClientSession` rather than creating a new one per request.

Changes:
- `Auth.__init__()` accepts optional `session` parameter
- `RestAuth.__init__()` accepts optional `session` parameter
- `HybridAuth.__init__()` accepts optional `session` parameter
- `Hydrawise.__init__()` accepts optional `session` and passes it to `AIOHTTPTransport`

Closes #242