### PR TITLE
fix: fetch full git history in PyPI publish workflow

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
The `Publish to PyPI` workflow was failing with a `400 Bad Request` from PyPI because the package was being built as version `0.1.dev1+g<hash>` instead of the release tag (e.g. `2026.6.0`).

**Root cause:** This project uses `setuptools_scm` to derive its version from git tags. The `actions/checkout` step defaults to `fetch-depth: 1` (shallow clone), which strips tag history. Without tags, `setuptools_scm` falls back to a dev version string that PyPI rejects.

**Fix:** Add `fetch-depth: 0` to the checkout step so the full tag history is available.

Note: `2026.6.0` was never actually published to PyPI — once this PR is merged, the workflow will need to be manually re-run against the `2026.6.0` tag.