### PR TITLE
Don't let REST-fallback originate zone suspensions from an ambiguous sentinel

### DIFF
--- a/pydrawise/hybrid.py
+++ b/pydrawise/hybrid.py
@@ -224,7 +224,10 @@ class HybridClient(HydrawiseBase):
             zones = []
             for zone_json in json["relays"]:
                 if zone := self._zones.get(zone_json["relay_id"]):
-                    zone.update_with_json(zone_json)
+                    # This zone was last populated by the GraphQL API (or by a
+                    # prior REST update layered on top of one), so it's a more
+                    # reliable source of truth than this REST poll alone.
+                    zone.update_with_json(zone_json, trust_suspension_sentinel=False)
                 else:
                     # Not an ideal case. This means we discovered a Zone from the
                     # REST API, which means we get incomplete data.

--- a/pydrawise/schema.py
+++ b/pydrawise/schema.py
@@ -440,7 +440,9 @@ class Zone(BaseZone):
         zone.update_with_json(zone_json)
         return zone
 
-    def update_with_json(self, zone_json: dict) -> None:
+    def update_with_json(
+        self, zone_json: dict, *, trust_suspension_sentinel: bool = True
+    ) -> None:
         current_run = None
         next_run = None
         if zone_json["time"] == 1:
@@ -450,8 +452,21 @@ class Zone(BaseZone):
             )
             self.status = ZoneStatus(suspended_until=None)
         elif zone_json["time"] == 1576800000 or zone_json.get("type") == 110:
-            # Zone is permanently suspended (REST API sentinel values).
-            self.status = ZoneStatus(suspended_until=datetime.max)
+            # The REST API sends this same sentinel both for a truly
+            # suspended zone and for one that's merely being held off by
+            # e.g. a rain sensor -- it can't tell the two apart. Callers that
+            # already have a more reliable source of truth for this zone
+            # (e.g. HybridClient, which only falls back to REST when its
+            # cached zone was last populated by the GraphQL API) pass
+            # trust_suspension_sentinel=False so the sentinel is only used to
+            # corroborate a suspension we already know about, never to
+            # originate one -- treating it as authoritative produced false
+            # positives that then flapped back to unsuspended on the next
+            # GraphQL poll. Callers with no other source of truth (e.g. a
+            # brand new Zone built straight from REST data) keep the default
+            # of trusting it, since it's the only signal available.
+            if trust_suspension_sentinel or self.status.suspended_until is not None:
+                self.status = ZoneStatus(suspended_until=datetime.max)
         else:
             start_time = _now() + timedelta(seconds=zone_json["time"])
             duration = timedelta(seconds=zone_json["run"])

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -11,7 +11,7 @@ from pydrawise.auth import HybridAuth
 from pydrawise.client import Hydrawise
 from pydrawise.exceptions import NotAuthorizedError
 from pydrawise.hybrid import HybridClient, Throttler
-from pydrawise.schema import Controller, Zone
+from pydrawise.schema import Controller, Zone, ZoneStatus
 from pydrawise.schema_utils import deserialize
 
 FROZEN_TIME = "2023-01-01 01:00:00"
@@ -284,6 +284,41 @@ async def test_get_zones_preserves_gql_suspension_across_rest_fallback(
 
         # The suspension must survive the REST poll instead of being wiped.
         assert zone2.status.suspended_until == suspended_until
+
+
+async def test_get_zones_rain_sensor_hold_does_not_falsely_suspend(
+    api, hybrid_auth, mock_gql_client, controller, zone, status_schedule
+):
+    """Regression test for #176404.
+
+    A zone GraphQL reports as active (not suspended) must stay active across
+    a REST-fallback poll, even when the REST payload sends the same 'not
+    scheduled to run' sentinel it uses for suspended zones -- e.g. because a
+    physical rain sensor is holding the zone's next run off. Treating that
+    sentinel as authoritative previously caused Home Assistant's automatic
+    watering switch to flap between on and off while the rain sensor was wet.
+    """
+    zone.status = ZoneStatus(suspended_until=None)
+    with freeze_time(FROZEN_TIME):
+        # First and second fetches query the GraphQL API and confirm the zone
+        # is active.
+        mock_gql_client.get_zones.return_value = [deepcopy(zone)]
+        assert await api.get_zones(controller) == [zone]
+        mock_gql_client.get_zones.reset_mock()
+        assert await api.get_zones(controller) == [zone]
+
+        # Third fetch: GraphQL is throttled, so we fall back to REST. A rain
+        # sensor is holding the zone off, which the REST API reports using
+        # the same sentinel as a real suspension.
+        mock_gql_client.get_zones.reset_mock()
+        status_schedule["relays"] = [status_schedule["relays"][0]]
+        status_schedule["relays"][0]["time"] = 1576800000
+        hybrid_auth.get.return_value = status_schedule
+        [zone2] = await api.get_zones(controller)
+        mock_gql_client.get_zones.assert_not_awaited()
+
+        # The zone must not be falsely reported as suspended.
+        assert zone2.status.suspended_until is None
 
 
 async def test_get_user_get_zones(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -262,3 +262,50 @@ def test_update_with_json_sets_permanent_suspension_from_type_110():
     zone.update_with_json(_relay_json(time_=339777, type_=110))
 
     assert zone.status.suspended_until == datetime.max
+
+
+def test_update_with_json_untrusted_sentinel_does_not_originate_suspension():
+    """Regression test for #176404.
+
+    The REST API sends the same 'not scheduled to run' sentinel when a zone
+    is merely being held off by a rain sensor as it does for a truly
+    suspended zone -- it can't tell the two apart. Callers that already have
+    a more reliable source of truth (e.g. HybridClient, whose cached zone was
+    last populated by the GraphQL API) pass trust_suspension_sentinel=False.
+    If we don't already have a reason to believe the zone is suspended, the
+    sentinel must not be treated as authoritative in that case, or a
+    rain-sensor hold would falsely flip the zone to suspended until the next
+    GraphQL poll corrects it -- causing Home Assistant's automatic watering
+    switch to flap.
+    """
+    zone = _zone(None)
+
+    zone.update_with_json(
+        _relay_json(time_=1576800000), trust_suspension_sentinel=False
+    )
+
+    assert zone.status.suspended_until is None
+
+
+def test_update_with_json_untrusted_type_110_does_not_originate_suspension():
+    zone = _zone(None)
+
+    zone.update_with_json(
+        _relay_json(time_=339777, type_=110), trust_suspension_sentinel=False
+    )
+
+    assert zone.status.suspended_until is None
+
+
+def test_update_with_json_untrusted_sentinel_still_corroborates_known_suspension():
+    """Even with trust_suspension_sentinel=False, a REST sentinel corroborates
+    a suspension we already know about (e.g. from the GraphQL API) rather
+    than being ignored outright."""
+    suspended_until = datetime(2026, 8, 1, 12, 0, 0)
+    zone = _zone(suspended_until)
+
+    zone.update_with_json(
+        _relay_json(time_=1576800000), trust_suspension_sentinel=False
+    )
+
+    assert zone.status.suspended_until == datetime.max


### PR DESCRIPTION
## Problem

Home Assistant's automatic watering switch flapped ON/OFF while a physical rain sensor was WET (#176404), even though nothing about the zone's real suspension state was changing.

## Root cause

`HybridClient` falls back to a legacy REST endpoint (`statusschedule.php`) when the GraphQL API is throttled. That endpoint reports a zone as "not scheduled to run" using the same sentinel (`time=1576800000` or `type=110`) both for a genuinely suspended zone and for one that's merely being held off by an active rain sensor — it can't distinguish the two.

Before this change, `Zone.update_with_json()` always treated that sentinel as authoritative confirmation of a permanent suspension. So the flow was:

1. GraphQL fetch reports the zone as active → switch ON (correct)
2. GraphQL throttled → REST fallback → rain sensor produces the sentinel → zone falsely marked suspended → switch OFF
3. Next GraphQL fetch → zone reported active again → switch back ON
4. Repeat every time GraphQL is throttled while the rain sensor is wet

Analysis and reproduction from the original report: dknowles2/pydrawise#516

## Fix

`Zone.update_with_json()` gains a `trust_suspension_sentinel` flag (default `True`, preserving existing behavior for callers with no other source of truth — e.g. `RestClient`, which builds a fresh `Zone` straight from REST data with nothing to fall back on, per #443).

`HybridClient._update_zones()` passes `trust_suspension_sentinel=False` specifically when updating a zone it already has cached from a prior GraphQL fetch. In that case the REST sentinel can only *corroborate* a suspension already known about — it can never *originate* one. If GraphQL last confirmed the zone active, the ambiguous REST signal is ignored and the zone stays active; a genuinely new suspension (e.g. made through the Hydrawise app) will still be picked up on the next GraphQL poll, at most ~30 minutes later.

Builds on #506 (fixes #493), which restructured `update_with_json()`'s branches to each own their own `self.status` assignment — this PR extends that same "don't let REST assert something it can't actually know" principle to the sentinel branch.

## Tests

- `tests/test_schema.py`: unit tests on `Zone.update_with_json()` covering the new `trust_suspension_sentinel` parameter — default (trusting) origination behavior, untrusted non-origination, and untrusted corroboration of an already-known suspension.
- `tests/test_hybrid.py`: `test_get_zones_rain_sensor_hold_does_not_falsely_suspend`, an end-to-end regression test reproducing the exact reported bug through `HybridClient`. Verified it fails with a `TypeError` against #506 alone (parameter doesn't exist) and passes with this fix.

Full suite: 67/67 relevant tests pass (8 pre-existing, unrelated timezone-dependent failures in `test_client.py`/`test_rest.py` present on `main` too).