### PR TITLE
Fix zone-suspension timestamp bug; improve test reliability and coverage

### DIFF
--- a/pydrawise/__init__.py
+++ b/pydrawise/__init__.py
@@ -8,6 +8,7 @@ from .exceptions import (
     MutationError,
     NotAuthenticatedError,
     NotAuthorizedError,
+    ThrottledError,
     UnknownError,
 )
 from .schema import Controller, Sensor, User, Zone
@@ -22,6 +23,7 @@ __all__ = (
     "NotAuthenticatedError",
     "NotAuthorizedError",
     "Sensor",
+    "ThrottledError",
     "UnknownError",
     "User",
     "Zone",

--- a/pydrawise/exceptions.py
+++ b/pydrawise/exceptions.py
@@ -6,7 +6,7 @@ class Error(Exception):
 
 
 class NotAuthenticatedError(Error):
-    """Raised when a request is made to an unathenticated object."""
+    """Raised when a request is made to an unauthenticated object."""
 
 
 class NotAuthorizedError(Error):

--- a/pydrawise/schema.py
+++ b/pydrawise/schema.py
@@ -152,7 +152,7 @@ class DateTime:
             # Make sure we have a timezone set so strftime outputs a valid string.
             local = local.replace(tzinfo=datetime.now(timezone.utc).astimezone().tzinfo)
         return DateTime(
-            value=local.strftime("%a, %d %b %y %H:%I:%S %z"),
+            value=local.strftime("%a, %d %b %y %H:%M:%S %z"),
             timestamp=int(dt.timestamp()),
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import os
+import time
 from unittest import mock
 
 import aiohttp
@@ -7,6 +9,12 @@ from pytest import fixture
 
 from pydrawise.schema import Controller, Sensor, User, Zone
 from pydrawise.schema_utils import deserialize
+
+# A number of tests assert on UTC offsets and epoch timestamps derived from
+# naive datetimes. Pin the process timezone to UTC so those assertions are
+# reproducible on any contributor's machine, not just UTC CI runners.
+os.environ["TZ"] = "UTC"
+time.tzset()
 
 
 class MockServer:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -246,7 +246,7 @@ async def test_suspend_zone(api: Hydrawise, mock_session, zone_json):
     query = print_ast(selector.document)
     assert "suspendZone(" in query
     assert "zoneId: 266" in query
-    assert 'until: "Sun, 01 Jan 23 00:12:00 +0000"' in query
+    assert 'until: "Sun, 01 Jan 23 00:00:00 +0000"' in query
 
 
 async def test_resume_zone(api: Hydrawise, mock_session, zone_json):
@@ -269,7 +269,7 @@ async def test_suspend_all_zones(api: Hydrawise, mock_session, controller_json):
     query = print_ast(selector.document)
     assert "suspendAllZones(" in query
     assert "controllerId: 9876" in query
-    assert 'until: "Sun, 01 Jan 23 00:12:00 +0000"' in query
+    assert 'until: "Sun, 01 Jan 23 00:00:00 +0000"' in query
 
 
 async def test_resume_all_zones(api: Hydrawise, mock_session, controller_json):

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -11,7 +11,7 @@ from pydrawise.auth import HybridAuth
 from pydrawise.client import Hydrawise
 from pydrawise.exceptions import NotAuthorizedError
 from pydrawise.hybrid import HybridClient, Throttler
-from pydrawise.schema import Controller, Zone, ZoneStatus
+from pydrawise.schema import Controller, Zone, ZoneStatus, ZoneSuspension
 from pydrawise.schema_utils import deserialize
 
 FROZEN_TIME = "2023-01-01 01:00:00"
@@ -426,3 +426,84 @@ async def test_get_zones_all_controllers_rest_error(
         hybrid_auth.get.side_effect = NotAuthorizedError("API key not valid")
         with pytest.raises(NotAuthorizedError):
             await api.get_controllers()
+
+
+async def test_start_zone(api, mock_gql_client, zone):
+    await api.start_zone(zone, mark_run_as_scheduled=True, custom_run_duration=60)
+    mock_gql_client.start_zone.assert_awaited_once_with(zone, True, 60)
+
+
+async def test_stop_zone(api, mock_gql_client, zone):
+    await api.stop_zone(zone)
+    mock_gql_client.stop_zone.assert_awaited_once_with(zone)
+
+
+async def test_start_all_zones(api, mock_gql_client, controller):
+    await api.start_all_zones(
+        controller, mark_run_as_scheduled=True, custom_run_duration=60
+    )
+    mock_gql_client.start_all_zones.assert_awaited_once_with(controller, True, 60)
+
+
+async def test_stop_all_zones(api, mock_gql_client, controller):
+    await api.stop_all_zones(controller)
+    mock_gql_client.stop_all_zones.assert_awaited_once_with(controller)
+
+
+async def test_suspend_zone(api, mock_gql_client, zone):
+    until = datetime(2023, 1, 1)
+    await api.suspend_zone(zone, until)
+    mock_gql_client.suspend_zone.assert_awaited_once_with(zone, until)
+
+
+async def test_resume_zone(api, mock_gql_client, zone):
+    await api.resume_zone(zone)
+    mock_gql_client.resume_zone.assert_awaited_once_with(zone)
+
+
+async def test_suspend_all_zones(api, mock_gql_client, controller):
+    until = datetime(2023, 1, 1)
+    await api.suspend_all_zones(controller, until)
+    mock_gql_client.suspend_all_zones.assert_awaited_once_with(controller, until)
+
+
+async def test_resume_all_zones(api, mock_gql_client, controller):
+    await api.resume_all_zones(controller)
+    mock_gql_client.resume_all_zones.assert_awaited_once_with(controller)
+
+
+async def test_delete_zone_suspension(api, mock_gql_client):
+    suspension = ZoneSuspension(id=42)
+    await api.delete_zone_suspension(suspension)
+    mock_gql_client.delete_zone_suspension.assert_awaited_once_with(suspension)
+
+
+async def test_get_water_flow_summary(api, mock_gql_client, controller, rain_sensor):
+    start = datetime(2023, 1, 1)
+    end = datetime(2023, 1, 2)
+    mock_gql_client.get_water_flow_summary.return_value = "summary"
+    result = await api.get_water_flow_summary(controller, rain_sensor, start, end)
+    assert result == "summary"
+    mock_gql_client.get_water_flow_summary.assert_awaited_once_with(
+        controller, rain_sensor, start, end
+    )
+
+
+async def test_get_watering_report(api, mock_gql_client, controller):
+    start = datetime(2023, 1, 1)
+    end = datetime(2023, 1, 2)
+    mock_gql_client.get_watering_report.return_value = ["entry"]
+    result = await api.get_watering_report(controller, start, end)
+    assert result == ["entry"]
+    mock_gql_client.get_watering_report.assert_awaited_once_with(controller, start, end)
+
+
+async def test_get_water_use_summary(api, mock_gql_client, controller):
+    start = datetime(2023, 1, 1)
+    end = datetime(2023, 1, 2)
+    mock_gql_client.get_water_use_summary.return_value = "summary"
+    result = await api.get_water_use_summary(controller, start, end)
+    assert result == "summary"
+    mock_gql_client.get_water_use_summary.assert_awaited_once_with(
+        controller, start, end
+    )


### PR DESCRIPTION
## Summary

Ran a codebase audit (code cleanliness, stray TODOs, test coverage) and fixed what came out of it:

- **Bug fix**: `DateTime.to_json()` in `pydrawise/schema.py` formatted the `until` value sent to the `suspendZone`/`suspendAllZones` GraphQL mutations with `%I` (12-hour clock) instead of `%M` (minutes). This has been wrong since the original 2023 commit — e.g. a suspension until `00:00:00` was serialized as `00:12:00`. The existing tests actually asserted on the buggy string instead of catching it; updated them to the correct expected value.
- **Test reliability**: several tests hardcode UTC epoch/offset values derived from naive `datetime` objects (`.timestamp()`, `strftime("%z")`). These only passed by coincidence because CI runs on UTC (`ubuntu-latest`); they fail for any contributor running tests in a non-UTC timezone (reproduced locally). Pinned the test process timezone to UTC in `conftest.py` via `time.tzset()`.
- **Test coverage**: `HybridClient`'s passthrough methods (`start_zone`, `stop_zone`, `start_all_zones`, `stop_all_zones`, `suspend_zone`, `resume_zone`, `suspend_all_zones`, `resume_all_zones`, `delete_zone_suspension`, `get_water_flow_summary`, `get_watering_report`, `get_water_use_summary`) had zero test coverage. Added 12 tests. `hybrid.py` coverage: 90% → 97%; overall: 95% → 97%.
- **Minor cleanup**: exported `ThrottledError` from the package root (it's raised by public `HybridClient` API but wasn't importable like the other exceptions), and fixed an "unathenticated" docstring typo.

Not included here (flagged during the audit but left as judgment calls rather than unilateral changes):
- `hybrid.py`'s `throttle` decorator uses a module-level cache dict shared across all `HybridClient` instances for the process lifetime with no eviction — a latent memory-leak/multi-tenancy smell worth a design decision.
- `.pre-commit-config.yaml` pins `ruff-pre-commit` at `v0.8.1` while `requirements-test.txt` pins `ruff==0.15.22`; the formatters disagree slightly (visible as latent format drift in `client.py`/`test_schema.py`). Worth aligning the versions.
- `NotAuthenticatedError` is defined/exported but never raised anywhere — dead code or reserved for future use.

## Test plan

- [x] `pytest` — 87 passed
- [x] `ruff check` — clean
- [x] `mypy pydrawise` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)