### PR TITLE
Fix zone-suspension timestamp minutes bug

### DIFF
--- a/pydrawise/schema.py
+++ b/pydrawise/schema.py
@@ -152,7 +152,7 @@ class DateTime:
             # Make sure we have a timezone set so strftime outputs a valid string.
             local = local.replace(tzinfo=datetime.now(timezone.utc).astimezone().tzinfo)
         return DateTime(
-            value=local.strftime("%a, %d %b %y %H:%I:%S %z"),
+            value=local.strftime("%a, %d %b %y %H:%M:%S %z"),
             timestamp=int(dt.timestamp()),
         )
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -246,7 +246,7 @@ async def test_suspend_zone(api: Hydrawise, mock_session, zone_json):
     query = print_ast(selector.document)
     assert "suspendZone(" in query
     assert "zoneId: 266" in query
-    assert 'until: "Sun, 01 Jan 23 00:12:00 +0000"' in query
+    assert 'until: "Sun, 01 Jan 23 00:00:00 +0000"' in query
 
 
 async def test_resume_zone(api: Hydrawise, mock_session, zone_json):
@@ -269,7 +269,7 @@ async def test_suspend_all_zones(api: Hydrawise, mock_session, controller_json):
     query = print_ast(selector.document)
     assert "suspendAllZones(" in query
     assert "controllerId: 9876" in query
-    assert 'until: "Sun, 01 Jan 23 00:12:00 +0000"' in query
+    assert 'until: "Sun, 01 Jan 23 00:00:00 +0000"' in query
 
 
 async def test_resume_all_zones(api: Hydrawise, mock_session, controller_json):


### PR DESCRIPTION
## Summary
- `DateTime.to_json()` in `pydrawise/schema.py` formatted the `until` value sent to the `suspendZone`/`suspendAllZones` GraphQL mutations with `%I` (12-hour clock) instead of `%M` (minutes), so suspension end-times sent to the API had garbage minutes — e.g. `00:00:00` was serialized as `00:12:00`.
- This has been wrong since the original 2023 commit. The existing tests actually asserted on the buggy string instead of catching it; updated them to the correct expected value.

## Test plan
- [x] `pytest` — passes in a UTC environment (these tests hardcode UTC-offset assertions; see #525 for the timezone-pinning fix, which is independent and unlocks that in non-UTC dev environments)
- [x] `ruff check` / `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)