### PR TITLE
Pin test process timezone to UTC

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import os
+import time
 from unittest import mock
 
 import aiohttp
@@ -7,6 +9,12 @@ from pytest import fixture
 
 from pydrawise.schema import Controller, Sensor, User, Zone
 from pydrawise.schema_utils import deserialize
+
+# A number of tests assert on UTC offsets and epoch timestamps derived from
+# naive datetimes. Pin the process timezone to UTC so those assertions are
+# reproducible on any contributor's machine, not just UTC CI runners.
+os.environ["TZ"] = "UTC"
+time.tzset()
 
 
 class MockServer:


### PR DESCRIPTION
## Summary
Several tests hardcode UTC epoch/offset values derived from naive `datetime` objects (`.timestamp()`, `strftime("%z")`). These only pass by coincidence because CI runs on `ubuntu-latest` (UTC); they fail for any contributor running the suite in a non-UTC local timezone (reproduced locally in EDT — 8 failures). Pin the test process to UTC via `time.tzset()` in `conftest.py` so the suite is reproducible everywhere.

## Test plan
- [x] `pytest` — 75 passed locally (in EDT), where previously 8 tests failed
- [x] `ruff check` / `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)