### PR TITLE
Export ThrottledError from package root; fix docstring typo

### DIFF
--- a/pydrawise/__init__.py
+++ b/pydrawise/__init__.py
@@ -8,6 +8,7 @@ from .exceptions import (
     MutationError,
     NotAuthenticatedError,
     NotAuthorizedError,
+    ThrottledError,
     UnknownError,
 )
 from .schema import Controller, Sensor, User, Zone
@@ -22,6 +23,7 @@ __all__ = (
     "NotAuthenticatedError",
     "NotAuthorizedError",
     "Sensor",
+    "ThrottledError",
     "UnknownError",
     "User",
     "Zone",

--- a/pydrawise/exceptions.py
+++ b/pydrawise/exceptions.py
@@ -6,7 +6,7 @@ class Error(Exception):
 
 
 class NotAuthenticatedError(Error):
-    """Raised when a request is made to an unathenticated object."""
+    """Raised when a request is made to an unauthenticated object."""
 
 
 class NotAuthorizedError(Error):


### PR DESCRIPTION
## Summary
- `ThrottledError` is raised by the public `HybridClient` API but wasn't importable from `pydrawise` directly like the other exceptions (`MutationError`, `NotAuthorizedError`, etc.). Exported it for consistency.
- Fixed an "unathenticated" typo in `NotAuthenticatedError`'s docstring.

## Test plan
- [x] `pytest` clean
- [x] `ruff check` / `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)