### PR TITLE
Fix incorrect docstrings and README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ if __name__ == "__main__":
 
 ### Pip
 
-To install pydrawse, run this command in your terminal:
+To install pydrawise, run this command in your terminal:
 
 ```sh
 $ pip install pydrawise

--- a/pydrawise/base.py
+++ b/pydrawise/base.py
@@ -169,7 +169,7 @@ class HydrawiseBase(ABC):
         :param sensor: Sensor for which a water flow summary is fetched.
         :param start:
         :param end:
-        :rtype: list[Sensor]
+        :rtype: SensorFlowSummary
         """
 
     @abstractmethod

--- a/pydrawise/client.py
+++ b/pydrawise/client.py
@@ -356,7 +356,7 @@ class Hydrawise(HydrawiseBase):
         :param sensor: Sensor for which a water flow summary is fetched.
         :param start:
         :param end:
-        :rtype: list[Sensor]
+        :rtype: SensorFlowSummary
         """
         result = await self._query(
             DSL_SCHEMA.Query.controller(controllerId=controller.id).select(

--- a/pydrawise/rest.py
+++ b/pydrawise/rest.py
@@ -65,10 +65,10 @@ class RestClient(HydrawiseBase):
         return controllers
 
     async def get_controller(self, controller_id: int) -> Controller:
-        """Retrieves a single controller by its unique identifier.
+        """Not supported by the Hydrawise v1 REST API.
 
         :param controller_id: Unique identifier for the controller to retrieve.
-        :rtype: Controller
+        :raises NotImplementedError: always.
         """
         _ = controller_id  # unused
         raise NotImplementedError
@@ -83,10 +83,10 @@ class RestClient(HydrawiseBase):
         return [Zone.from_json(z) for z in resp_json["relays"]]
 
     async def get_zone(self, zone_id: int) -> Zone:
-        """Retrieves a zone by its unique identifier.
+        """Not supported by the Hydrawise v1 REST API.
 
         :param zone_id: The zone's unique identifier.
-        :rtype: Zone
+        :raises NotImplementedError: always.
         """
         _ = zone_id  # unused
         raise NotImplementedError
@@ -196,11 +196,10 @@ class RestClient(HydrawiseBase):
         )
 
     async def delete_zone_suspension(self, suspension: ZoneSuspension) -> None:
-        """Removes a specific zone suspension.
-
-        Useful when there are multiple suspensions for a zone in effect.
+        """Not supported by the Hydrawise v1 REST API.
 
         :param suspension: The suspension to delete.
+        :raises NotImplementedError: always.
         """
         _ = suspension  # unused
         raise NotImplementedError


### PR DESCRIPTION
## Summary
- Fix a typo in the README install instructions: `pip install pydrawse` → `pydrawise`.
- Fix `get_water_flow_summary()` docstrings (in both `HydrawiseBase` and `Hydrawise`) that claimed `:rtype: list[Sensor]` when the method actually returns a `SensorFlowSummary`.
- Fix three `RestClient` methods (`get_controller`, `get_zone`, `delete_zone_suspension`) whose docstrings described normal behavior even though they always `raise NotImplementedError` — the v1 REST API doesn't support these operations.

No behavior changes; docstrings/README text only.

## Test plan
- [x] `pytest` (87 passed)
- [x] `ruff check pydrawise/`
- [x] `mypy pydrawise/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)