### PR TITLE
Document HybridClient, RestClient, and LegacyHydrawise; add usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
+The example above uses `pydrawise.Hydrawise`, which talks to Hydrawise's GraphQL API. Pydrawise
+also provides a REST API client (`pydrawise.rest.RestClient`) and a hybrid client
+(`pydrawise.hybrid.HybridClient`) that prefers GraphQL but falls back to REST when GraphQL
+requests are throttled. See the [usage guide](https://pydrawise.readthedocs.io/en/latest/usage/)
+for more examples, and the [full API reference](https://pydrawise.readthedocs.io/en/latest/reference/)
+for details.
+
 ## Installation
 
 ### Pip

--- a/docs/reference/auth.md
+++ b/docs/reference/auth.md
@@ -1,0 +1,11 @@
+# pydrawise.auth
+
+::: pydrawise.auth
+    options:
+      show_root_heading: true
+      filters:
+        - "!^_"
+        - "!^Auth$"
+        - "!^Token$"
+        - "!^DEFAULT_TIMEOUT$"
+        - "^__init__$"

--- a/docs/reference/hybrid.md
+++ b/docs/reference/hybrid.md
@@ -1,0 +1,12 @@
+# pydrawise.hybrid
+
+::: pydrawise.hybrid
+    options:
+      show_root_heading: true
+      filters:
+        - "!^_"
+        - "!^Throttler$"
+        - "!^throttle$"
+        - "!^P$"
+        - "!^T$"
+        - "^__init__$"

--- a/docs/reference/legacy.md
+++ b/docs/reference/legacy.md
@@ -1,0 +1,8 @@
+# pydrawise.legacy
+
+::: pydrawise.legacy
+    options:
+      show_root_heading: true
+      filters:
+        - "!^_"
+        - "^__init__$"

--- a/docs/reference/rest.md
+++ b/docs/reference/rest.md
@@ -1,0 +1,8 @@
+# pydrawise.rest
+
+::: pydrawise.rest
+    options:
+      show_root_heading: true
+      filters:
+        - "!^_"
+        - "^__init__$"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,160 @@
+# Usage Guide
+
+## Quick start
+
+```python
+import asyncio
+
+from pydrawise import Auth, Hydrawise
+
+
+async def main():
+    # Create a Hydrawise object and authenticate with your credentials.
+    h = Hydrawise(Auth("username", "password"))
+
+    # List the controllers attached to your account.
+    controllers = await h.get_controllers()
+
+    # List the zones controlled by the first controller.
+    zones = await h.get_zones(controllers[0])
+
+    # Start the first zone.
+    await h.start_zone(zones[0])
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+## Choosing a client
+
+Pydrawise ships four client implementations, all of which implement the same
+[`HydrawiseBase`][pydrawise.HydrawiseBase] interface:
+
+| Client | Auth | Transport | When to use |
+| --- | --- | --- | --- |
+| [`Hydrawise`][pydrawise.Hydrawise] | [`Auth`][pydrawise.Auth] (username/password) | GraphQL | Default choice. Full-featured, asynchronous. |
+| [`HybridClient`][pydrawise.hybrid.HybridClient] | [`HybridAuth`][pydrawise.auth.HybridAuth] (username/password + API key) | GraphQL, falling back to REST | Applications that poll frequently (e.g. Home Assistant) and want to stay within Hydrawise's GraphQL rate limits. |
+| [`RestClient`][pydrawise.rest.RestClient] | [`RestAuth`][pydrawise.auth.RestAuth] (API key only) | REST v1 | You only have an API key, or don't need the features that require GraphQL (sensors, water reports, deleting a specific suspension). |
+| [`LegacyHydrawise`][pydrawise.legacy.LegacyHydrawise] | API key only | REST v1 | Synchronous, drop-in replacement for [hydrawiser](https://github.com/ptcryan/hydrawiser). |
+
+## Zone control
+
+```python
+# Run a zone for its default configured duration.
+await h.start_zone(zone)
+
+# Run a zone for a custom duration (in seconds).
+await h.start_zone(zone, custom_run_duration=600)
+
+# Stop a zone that's currently running.
+await h.stop_zone(zone)
+
+# Start or stop every zone on a controller at once.
+await h.start_all_zones(controller, custom_run_duration=600)
+await h.stop_all_zones(controller)
+```
+
+## Suspending and resuming zones
+
+```python
+from datetime import datetime, timedelta
+
+# Suspend a single zone for 24 hours (e.g. because of a rain forecast).
+until = datetime.now() + timedelta(days=1)
+await h.suspend_zone(zone, until)
+await h.resume_zone(zone)
+
+# Suspend or resume every zone on a controller.
+await h.suspend_all_zones(controller, until)
+await h.resume_all_zones(controller)
+
+# A zone can have multiple suspensions in effect; list and remove one specifically.
+zones = await h.get_zones(controller)
+for suspension in zones[0].suspensions:
+    await h.delete_zone_suspension(suspension)
+```
+
+## Sensors and water usage
+
+```python
+from datetime import datetime, timedelta
+
+controllers = await h.get_controllers(fetch_sensors=True)
+controller = controllers[0]
+sensors = await h.get_sensors(controller)
+
+start = datetime.now() - timedelta(days=7)
+end = datetime.now()
+
+# Water flow reported by a specific flow sensor.
+flow_summary = await h.get_water_flow_summary(controller, sensors[0], start, end)
+print(f"{flow_summary.total_water_volume.value} {flow_summary.total_water_volume.unit}")
+
+# Individual watering events (start/end time, duration, water used, why it stopped).
+for entry in await h.get_watering_report(controller, start, end):
+    run = entry.run_event
+    print(f"{run.zone.name}: {run.reported_duration} starting {run.reported_start_time}")
+
+# Aggregate water use across all zones, broken down by zone id.
+summary = await h.get_water_use_summary(controller, start, end)
+print(f"Active watering time: {summary.total_active_time}")
+for zone_id, use in summary.active_use_by_zone_id.items():
+    print(f"  zone {zone_id}: {use} {summary.unit}")
+```
+
+## Using the hybrid client
+
+[`HybridClient`][pydrawise.hybrid.HybridClient] prefers the GraphQL API but
+falls back to (and caches results from) the REST API once its GraphQL
+throttle budget is exhausted. It implements the same interface as
+[`Hydrawise`][pydrawise.Hydrawise], so it's a drop-in replacement for
+applications that poll on a fixed interval:
+
+```python
+from pydrawise import Auth
+from pydrawise.auth import HybridAuth
+from pydrawise.hybrid import HybridClient
+
+auth = HybridAuth("username", "password", "api_key")
+h = HybridClient(auth)
+controllers = await h.get_controllers()
+```
+
+## Using the REST-only client
+
+If you only have a Hydrawise API key (no username/password), use
+[`RestClient`][pydrawise.rest.RestClient] instead. Note that a handful of
+methods aren't available through the v1 REST API and always raise
+`NotImplementedError`: `get_controller`, `get_zone`,
+`delete_zone_suspension`, `get_sensors`, `get_water_flow_summary`,
+`get_watering_report`, and `get_water_use_summary`.
+
+```python
+from pydrawise.auth import RestAuth
+from pydrawise.rest import RestClient
+
+h = RestClient(RestAuth("api_key"))
+controllers = await h.get_controllers()
+```
+
+## Handling errors
+
+All pydrawise exceptions derive from [`Error`][pydrawise.Error]:
+
+```python
+from pydrawise import Auth, Hydrawise, NotAuthorizedError, ThrottledError, MutationError
+
+h = Hydrawise(Auth("username", "password"))
+
+try:
+    await h.start_zone(zone)
+except NotAuthorizedError:
+    print("Invalid credentials.")
+except ThrottledError:
+    # Raised by HybridClient when a request is throttled and no cached
+    # result is available yet.
+    print("Rate limited; try again later.")
+except MutationError as e:
+    print(f"Hydrawise rejected the request: {e}")
+```

--- a/pydrawise/auth.py
+++ b/pydrawise/auth.py
@@ -100,7 +100,10 @@ class RestAuth(BaseAuth):
     """Authentication support for the Hydrawise REST API."""
 
     def __init__(self, api_key: str) -> None:
-        """Initializer."""
+        """Initializer.
+
+        :param api_key: The API key to use for authenticating with the Hydrawise REST service.
+        """
         self._api_key = api_key
 
     async def get(self, path: str, **kwargs) -> dict:
@@ -125,7 +128,12 @@ class HybridAuth(Auth, RestAuth):
     """Authentication support for the Hydrawise GraphQL & REST APIs."""
 
     def __init__(self, username: str, password: str, api_key: str) -> None:
-        """Initializer."""
+        """Initializer.
+
+        :param username: The username to use for authenticating with the Hydrawise GraphQL service.
+        :param password: The password to use for authenticating with the Hydrawise GraphQL service.
+        :param api_key: The API key to use for authenticating with the Hydrawise REST service.
+        """
         Auth.__init__(self, username, password)
         RestAuth.__init__(self, api_key)
 
@@ -133,6 +141,7 @@ class HybridAuth(Auth, RestAuth):
         await self.get("customerdetails.php")
 
     async def check(self) -> bool:
+        """Validates that both the GraphQL credentials and the REST API key are valid."""
         await super().check()
         await self._check_api_token()
         return True

--- a/pydrawise/hybrid.py
+++ b/pydrawise/hybrid.py
@@ -31,6 +31,14 @@ _LOGGER = logging.getLogger("pydrawise")
 
 @dataclass
 class Throttler:
+    """Tracks a token budget for calls made within a recurring time window.
+
+    :param epoch_interval: Length of each recurring time window.
+    :param last_epoch: When the current window started.
+    :param tokens_per_epoch: Maximum number of tokens that may be spent per window.
+    :param tokens: Number of tokens already spent in the current window.
+    """
+
     epoch_interval: timedelta
     last_epoch: datetime = datetime.min
     tokens_per_epoch: int = 1
@@ -38,14 +46,20 @@ class Throttler:
 
     @property
     def next_epoch(self) -> datetime:
+        """When the current window ends and a new one begins."""
         return self.last_epoch + self.epoch_interval
 
     def check(self, tokens: int = 1) -> bool:
+        """Returns whether spending the given number of tokens is currently allowed.
+
+        :param tokens: Number of tokens the caller wants to spend.
+        """
         if datetime.now() > self.next_epoch:
             return tokens <= self.tokens_per_epoch
         return (self.tokens + tokens) <= self.tokens_per_epoch
 
     def mark(self) -> None:
+        """Records that a token was spent, starting a new window if necessary."""
         if (now := datetime.now()) > self.next_epoch:
             self.last_epoch = now
             self.tokens = 1
@@ -54,6 +68,7 @@ class Throttler:
 
     @property
     def debug_str(self) -> str:
+        """A human-readable summary of the throttler's current state."""
         next_epoch_delta = self.next_epoch - datetime.now()
         return f"{self.tokens}/{self.tokens_per_epoch} tokens used; next epoch in: {next_epoch_delta}"
 
@@ -63,6 +78,16 @@ P = ParamSpec("P")
 
 
 def throttle(fn: Callable[P, Awaitable[T]]) -> Callable[P, Coroutine[None, None, T]]:
+    """Decorator that throttles a HybridClient GraphQL-backed method.
+
+    Calls are keyed by their first positional argument (a Controller's id, or
+    the argument itself if it isn't a Controller). While the GraphQL throttle
+    has budget, the wrapped method is called and its result cached. Once the
+    throttle is exhausted, the cached result for that key is returned instead;
+    if there is no cached result yet, ThrottledError is raised.
+
+    :param fn: The bound HybridClient method to wrap.
+    """
     cache: dict[str, T] = {}
 
     @wraps(fn)
@@ -84,6 +109,17 @@ def throttle(fn: Callable[P, Awaitable[T]]) -> Callable[P, Coroutine[None, None,
 
 
 class HybridClient(HydrawiseBase):
+    """Client library that uses both the GraphQL and REST Hydrawise APIs.
+
+    Prefers the GraphQL API, but falls back to (and caches results from) the
+    REST API when GraphQL requests are throttled. This is useful for
+    applications that poll frequently and want to stay within Hydrawise's
+    GraphQL rate limits.
+
+    Should be instantiated with a HybridAuth object that handles
+    authentication and low-level transport for both APIs.
+    """
+
     def __init__(
         self,
         auth: HybridAuth,
@@ -92,6 +128,14 @@ class HybridClient(HydrawiseBase):
         gql_throttle: Throttler | None = None,
         rest_throttle: Throttler | None = None,
     ) -> None:
+        """Initializes the client.
+
+        :param auth: Handles authentication and transport for both APIs.
+        :param app_id: Unique identifier for the application accessing the Hydrawise API.
+        :param gql_client: GraphQL client to use. If not specified, one will be created.
+        :param gql_throttle: Throttler controlling how often the GraphQL API may be called.
+        :param rest_throttle: Throttler controlling how often the REST API may be called.
+        """
         if gql_client is None:
             gql_client = Hydrawise(auth, app_id)
         self._gql_client = gql_client
@@ -112,6 +156,14 @@ class HybridClient(HydrawiseBase):
         self._rest_throttle: Throttler = rest_throttle
 
     async def get_user(self, fetch_zones: bool = True) -> User:
+        """Retrieves the currently authenticated user.
+
+        Uses the GraphQL API while it has throttle budget, refreshing zones
+        from the REST API otherwise.
+
+        :param fetch_zones: Whether to include zones in the controller response.
+        :rtype: User
+        """
         async with self._lock:
             if self._user is None or self._gql_throttle.check():
                 self._user = await self._gql_client.get_user(fetch_zones=fetch_zones)
@@ -134,6 +186,16 @@ class HybridClient(HydrawiseBase):
     async def get_controllers(
         self, fetch_zones: bool = True, fetch_sensors: bool = True
     ) -> list[Controller]:
+        """Retrieves all controllers associated with the currently authenticated user.
+
+        Uses the GraphQL API while it has throttle budget, refreshing zones
+        from the REST API otherwise. Results are cached and returned from the
+        cache on subsequent calls once throttled.
+
+        :param fetch_zones: Whether to include zones in the response.
+        :param fetch_sensors: Whether to include sensors in the response.
+        :rtype: list[Controller]
+        """
         async with self._lock:
             if not self._controllers or self._gql_throttle.check():
                 controllers = await self._gql_client.get_controllers(
@@ -157,6 +219,14 @@ class HybridClient(HydrawiseBase):
         return list(self._controllers.values())
 
     async def get_controller(self, controller_id: int) -> Controller:
+        """Retrieves a single controller by its unique identifier.
+
+        Uses the GraphQL API while it has throttle budget; otherwise returns
+        the cached controller.
+
+        :param controller_id: Unique identifier for the controller to retrieve.
+        :rtype: Controller
+        """
         async with self._lock:
             if not self._controllers.get(controller_id) or self._gql_throttle.check():
                 self._controllers[
@@ -170,6 +240,14 @@ class HybridClient(HydrawiseBase):
         return self._controllers[controller_id]
 
     async def get_zones(self, controller: Controller) -> list[Zone]:
+        """Retrieves zones associated with the given controller.
+
+        Uses the GraphQL API while it has throttle budget, refreshing from
+        the REST API otherwise.
+
+        :param controller: Controller whose zones to fetch.
+        :rtype: list[Zone]
+        """
         async with self._lock:
             if not self._controllers.get(controller.id) or self._gql_throttle.check():
                 zones = await self._gql_client.get_zones(controller)
@@ -240,6 +318,16 @@ class HybridClient(HydrawiseBase):
 
     @throttle
     async def get_zone(self, zone_id: int) -> Zone:
+        """Retrieves a zone by its unique identifier.
+
+        Always uses the GraphQL API (the REST API has no way to fetch a
+        single zone), throttled: once the GraphQL throttle is exhausted, the
+        last result for this zone id is returned instead, or ThrottledError
+        is raised if there is none yet.
+
+        :param zone_id: The zone's unique identifier.
+        :rtype: Zone
+        """
         # The REST API doesn't allow us to fetch a single zone, so we'll just
         # query the GraphQL API instead.
         #
@@ -257,11 +345,22 @@ class HybridClient(HydrawiseBase):
         mark_run_as_scheduled: bool = False,
         custom_run_duration: int = 0,
     ) -> None:
+        """Starts a zone's run cycle. Always uses the GraphQL API.
+
+        :param zone: The zone to start.
+        :param mark_run_as_scheduled: Whether to mark the zone as having run as scheduled.
+        :param custom_run_duration: Duration (in seconds) to run the zone. If not
+            specified (or zero), will run for its default configured time.
+        """
         return await self._gql_client.start_zone(
             zone, mark_run_as_scheduled, custom_run_duration
         )
 
     async def stop_zone(self, zone: Zone) -> None:
+        """Stops a zone. Always uses the GraphQL API.
+
+        :param zone: The zone to stop.
+        """
         return await self._gql_client.stop_zone(zone)
 
     async def start_all_zones(
@@ -270,35 +369,91 @@ class HybridClient(HydrawiseBase):
         mark_run_as_scheduled: bool = False,
         custom_run_duration: int = 0,
     ) -> None:
+        """Starts all zones attached to a controller. Always uses the GraphQL API.
+
+        :param controller: The controller whose zones to start.
+        :param mark_run_as_scheduled: Whether to mark the zones as having run as scheduled.
+        :param custom_run_duration: Duration (in seconds) to run the zones. If not
+            specified (or zero), will run for each zone's default configured time.
+        """
         return await self._gql_client.start_all_zones(
             controller, mark_run_as_scheduled, custom_run_duration
         )
 
     async def stop_all_zones(self, controller: Controller) -> None:
+        """Stops all zones attached to a controller. Always uses the GraphQL API.
+
+        :param controller: The controller whose zones to stop.
+        """
         return await self._gql_client.stop_all_zones(controller)
 
     async def suspend_zone(self, zone: Zone, until: datetime) -> None:
+        """Suspends a zone's schedule. Always uses the GraphQL API.
+
+        :param zone: The zone to suspend.
+        :param until: When the suspension should end.
+        """
         return await self._gql_client.suspend_zone(zone, until)
 
     async def resume_zone(self, zone: Zone) -> None:
+        """Resumes a zone's schedule. Always uses the GraphQL API.
+
+        :param zone: The zone whose schedule to resume.
+        """
         return await self._gql_client.resume_zone(zone)
 
     async def suspend_all_zones(self, controller: Controller, until: datetime) -> None:
+        """Suspends the schedule of all zones attached to a given controller.
+
+        Always uses the GraphQL API.
+
+        :param controller: The controller whose zones to suspend.
+        :param until: When the suspension should end.
+        """
         return await self._gql_client.suspend_all_zones(controller, until)
 
     async def resume_all_zones(self, controller: Controller) -> None:
+        """Resumes the schedule of all zones attached to the given controller.
+
+        Always uses the GraphQL API.
+
+        :param controller: The controller whose zones to resume.
+        """
         return await self._gql_client.resume_all_zones(controller)
 
     async def delete_zone_suspension(self, suspension: ZoneSuspension) -> None:
+        """Removes a specific zone suspension. Always uses the GraphQL API.
+
+        Useful when there are multiple suspensions for a zone in effect.
+
+        :param suspension: The suspension to delete.
+        """
         return await self._gql_client.delete_zone_suspension(suspension)
 
     @throttle
     async def get_sensors(self, controller: Controller) -> list[Sensor]:
+        """Retrieves sensors associated with the given controller.
+
+        Always uses the GraphQL API, throttled: once the GraphQL throttle is
+        exhausted, the last result for this controller is returned instead,
+        or ThrottledError is raised if there is none yet.
+
+        :param controller: Controller whose sensors to fetch.
+        :rtype: list[Sensor]
+        """
         return await self._gql_client.get_sensors(controller)
 
     async def get_water_flow_summary(
         self, controller: Controller, sensor: Sensor, start: datetime, end: datetime
     ) -> SensorFlowSummary:
+        """Retrieves the water flow summary for a given sensor. Always uses the GraphQL API.
+
+        :param controller: Controller that controls the sensor.
+        :param sensor: Sensor for which a water flow summary is fetched.
+        :param start:
+        :param end:
+        :rtype: SensorFlowSummary
+        """
         return await self._gql_client.get_water_flow_summary(
             controller, sensor, start, end
         )
@@ -306,9 +461,25 @@ class HybridClient(HydrawiseBase):
     async def get_watering_report(
         self, controller: Controller, start: datetime, end: datetime
     ) -> list[WateringReportEntry]:
+        """Retrieves a watering report for the given controller and time period.
+
+        Always uses the GraphQL API.
+
+        :param controller: The controller whose watering report to generate.
+        :param start: Start time.
+        :param end: End time.
+        """
         return await self._gql_client.get_watering_report(controller, start, end)
 
     async def get_water_use_summary(
         self, controller: Controller, start: datetime, end: datetime
     ) -> ControllerWaterUseSummary:
+        """Calculate the water use for the given controller and time period.
+
+        Always uses the GraphQL API.
+
+        :param controller: The controller whose water use to report.
+        :param start: Start time
+        :param end: End time.
+        """
         return await self._gql_client.get_water_use_summary(controller, start, end)

--- a/pydrawise/legacy.py
+++ b/pydrawise/legacy.py
@@ -24,6 +24,10 @@ class LegacyHydrawiseAsync(RestClient):
     """
 
     def __init__(self, user_token: str) -> None:
+        """Initializer.
+
+        :param user_token: The API key to use for authenticating with the Hydrawise service.
+        """
         super().__init__(RestAuth(user_token))
 
 
@@ -34,6 +38,12 @@ class LegacyHydrawise:
     """
 
     def __init__(self, user_token: str, load_on_init: bool = True) -> None:
+        """Initializer.
+
+        :param user_token: The API key to use for authenticating with the Hydrawise service.
+        :param load_on_init: Whether to synchronously fetch controller info and
+            status as part of initialization.
+        """
         self._api_key = user_token
         self.controller_info: dict[str, Any] = {}
         self.controller_status: dict[str, Any] = {}
@@ -42,6 +52,10 @@ class LegacyHydrawise:
 
     @property
     def current_controller(self) -> dict:
+        """The raw JSON for the account's first (or only) controller.
+
+        Empty if no controller info has been loaded yet.
+        """
         controllers = self.controller_info.get("controllers", [])
         if not controllers:
             return {}
@@ -49,46 +63,63 @@ class LegacyHydrawise:
 
     @property
     def status(self) -> str | None:
+        """Human-readable status string for the current controller (e.g. "All good!")."""
         return self.current_controller.get("status")
 
     @property
     def controller_id(self) -> int | None:
+        """Unique identifier of the current controller."""
         return self.current_controller.get("controller_id")
 
     @property
     def customer_id(self) -> int | None:
+        """Unique identifier of the authenticated customer account."""
         return self.controller_info.get("customer_id")
 
     @property
     def num_relays(self) -> int:
+        """Number of zones (relays) attached to the current controller."""
         return len(self.controller_status.get("relays", []))
 
     @property
     def relays(self) -> list[dict]:
+        """Raw JSON for each zone (relay) attached to the current controller.
+
+        Sorted by zone number.
+        """
         relays = self.controller_status.get("relays", [])
         return sorted(relays, key=lambda r: r["relay"])
 
     @property
     def relays_by_id(self) -> dict[int, dict]:
+        """Raw zone JSON keyed by each zone's unique relay id."""
         return {r["relay_id"]: r for r in self.controller_status.get("relays", [])}
 
     @property
     def relays_by_zone_number(self) -> dict[int, dict]:
+        """Raw zone JSON keyed by zone (relay) number."""
         return {r["relay"]: r for r in self.controller_status.get("relays", [])}
 
     @property
     def name(self) -> str | None:
+        """Name of the current controller."""
         return self.current_controller.get("name")
 
     @property
     def sensors(self) -> list[dict]:
+        """Raw JSON for the sensors attached to the current controller."""
         return self.controller_status.get("sensors", [])
 
     @property
     def running(self) -> str | None:
+        """Raw JSON describing the zone that is currently running, if any."""
         return self.controller_status.get("running")
 
     def update_controller_info(self) -> bool:
+        """Refreshes controller info and status from the Hydrawise service.
+
+        :rtype: bool
+        """
         self.controller_info = self._get_controller_info()
         self.controller_status = self._get_controller_status()
         return True
@@ -115,6 +146,14 @@ class LegacyHydrawise:
         return self._get("statusschedule.php")
 
     def suspend_zone(self, days: int, zone: int | None = None) -> dict:
+        """Suspends a zone's (or all zones') schedule for a number of days.
+
+        :param days: Number of days to suspend for, starting now. If not
+            positive, any existing suspension is cleared instead.
+        :param zone: Zone (relay) number to suspend. If not specified, all
+            zones on the current controller are suspended.
+        :rtype: dict
+        """
         params: dict[str, Any] = {}
 
         if days > 0:
@@ -135,6 +174,14 @@ class LegacyHydrawise:
         return self._get("setzone.php", **params)
 
     def run_zone(self, minutes: int, zone: int | None = None) -> dict:
+        """Starts or stops a zone's (or all zones') run cycle.
+
+        :param minutes: Number of minutes to run for. If not positive, the
+            zone(s) are stopped instead.
+        :param zone: Zone (relay) number to run or stop. If not specified,
+            all zones on the current controller are run or stopped.
+        :rtype: dict
+        """
         params: dict[str, Any] = {}
 
         if zone is not None:

--- a/pydrawise/rest.py
+++ b/pydrawise/rest.py
@@ -25,6 +25,10 @@ class RestClient(HydrawiseBase):
     """
 
     def __init__(self, auth: RestAuth) -> None:
+        """Initializer.
+
+        :param auth: Handles authentication and transport.
+        """
         self._auth = auth
         self.next_poll = timedelta(0)
 
@@ -206,19 +210,35 @@ class RestClient(HydrawiseBase):
         raise NotImplementedError
 
     async def get_sensors(self, controller: Controller) -> list[Sensor]:
+        """Not supported by the Hydrawise v1 REST API.
+
+        :raises NotImplementedError: always.
+        """
         raise NotImplementedError
 
     async def get_water_flow_summary(
         self, controller: Controller, sensor: Sensor, start: datetime, end: datetime
     ) -> SensorFlowSummary:
+        """Not supported by the Hydrawise v1 REST API.
+
+        :raises NotImplementedError: always.
+        """
         raise NotImplementedError
 
     async def get_watering_report(
         self, controller: Controller, start: datetime, end: datetime
     ) -> list[WateringReportEntry]:
+        """Not supported by the Hydrawise v1 REST API.
+
+        :raises NotImplementedError: always.
+        """
         raise NotImplementedError
 
     async def get_water_use_summary(
         self, controller: Controller, start: datetime, end: datetime
     ) -> ControllerWaterUseSummary:
+        """Not supported by the Hydrawise v1 REST API.
+
+        :raises NotImplementedError: always.
+        """
         raise NotImplementedError

--- a/pydrawise/schema.py
+++ b/pydrawise/schema.py
@@ -432,6 +432,12 @@ class Zone(BaseZone):
 
     @classmethod
     def from_json(cls, zone_json: dict) -> Zone:
+        """Builds a new Zone from a REST API "relay" JSON object.
+
+        :param zone_json: A single relay entry, as returned by the REST
+            API's statusschedule.php endpoint.
+        :rtype: Zone
+        """
         zone = Zone(
             id=zone_json["relay_id"],
             number=zone_json["relay"],
@@ -443,6 +449,17 @@ class Zone(BaseZone):
     def update_with_json(
         self, zone_json: dict, *, trust_suspension_sentinel: bool = True
     ) -> None:
+        """Updates this Zone's schedule and status from a REST API "relay" JSON object.
+
+        :param zone_json: A single relay entry, as returned by the REST
+            API's statusschedule.php endpoint.
+        :param trust_suspension_sentinel: Whether the REST API's ambiguous
+            "suspended" sentinel value should be treated as authoritative for
+            this zone. Callers with a more reliable source of truth (e.g.
+            HybridClient, once it already knows this zone's real suspension
+            state from the GraphQL API) should pass False so the sentinel can
+            only corroborate a suspension already known, never originate one.
+        """
         current_run = None
         next_run = None
         if zone_json["time"] == 1:
@@ -634,12 +651,16 @@ class ControllerStatus:
 
 @dataclass
 class RunStatusType:
+    """The status of a reported zone run."""
+
     value: int = 0
     label: str = ""
 
 
 @dataclass
 class RunStopReasonType:
+    """Why a reported zone run stopped."""
+
     finished_normally: bool = False
     description: list[str] = field(default_factory=list)
 
@@ -721,6 +742,12 @@ class Controller:
 
     @classmethod
     def from_json(cls, controller_json: dict) -> Controller:
+        """Builds a new Controller from a REST API "controller" JSON object.
+
+        :param controller_json: A single controller entry, as returned by
+            the REST API's customerdetails.php endpoint.
+        :rtype: Controller
+        """
         controller = Controller(
             id=controller_json["controller_id"],
             name=controller_json["name"],
@@ -732,6 +759,11 @@ class Controller:
         return controller
 
     def update_with_json(self, controller_json: dict) -> None:
+        """Updates this Controller's last contact time from a REST API "controller" JSON object.
+
+        :param controller_json: A single controller entry, as returned by
+            the REST API's customerdetails.php endpoint.
+        """
         self.last_contact_time = datetime.fromtimestamp(controller_json["last_contact"])
         self.online = True
 


### PR DESCRIPTION
## Summary
- `HybridClient`, `RestClient`, `LegacyHydrawise`, `RestAuth`, and `HybridAuth` are all fully tested, user-facing client implementations that had **zero** documentation anywhere — not in generated docs, not in the README. Add generated reference pages for them (`docs/reference/{hybrid,rest,legacy,auth}.md`).
- Backfill the docstrings those pages render. Coverage before this PR: `hybrid.py` 2/27, `legacy.py` 2/18, `rest.py` 15/20 (plus a few gaps in `schema.py`/`auth.py`). Full package coverage after.
- Add a Usage Guide (`docs/usage.md`) with worked examples: zone control, suspend/resume, sensor & water-use reporting, a client-selection table, and error handling — cross-linked into the generated reference.
- Add a short pointer from the README to the new usage guide and reference.

No behavior changes; docs/docstrings only.

## Test plan
- [x] `pytest` (87 passed)
- [x] `ruff check pydrawise/`
- [x] `mypy pydrawise/`
- [x] `mkdocs build --strict` (clean; verified every cross-reference link in the new usage guide resolves)

🤖 Generated with [Claude Code](https://claude.com/claude-code)