### PR TITLE
Remove orphaned isort config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,12 +49,6 @@ readme          = { file = ["README.md"], content-type = "text/markdown" }
 [tool.setuptools_scm]
 write_to = "pydrawise/_version.py"
 
-[tool.isort]
-profile                    = "black"
-combine_as_imports         = true
-force_sort_within_sections = true
-forced_separate            = ["tests"]
-
 [tool.ruff.lint]
 ignore = ["DTZ", "RUF009"]
 


### PR DESCRIPTION
## Summary
- \`[tool.isort]\` in pyproject.toml has had no effect for a while: isort isn't a project dependency, and no pre-commit hook or CI step invokes it. Ruff handles linting/formatting instead. Remove the dead config.

## Test plan
- [x] N/A (config removal only, no behavior change — verified isort isn't referenced anywhere else in the repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)