### PR TITLE
Consolidate pytest config into pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ combine_as_imports         = true
 force_sort_within_sections = true
 forced_separate            = ["tests"]
 
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+
 [tool.ruff.lint]
 ignore = ["DTZ", "RUF009"]
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-asyncio_mode = auto


### PR DESCRIPTION
## Summary
- Fold pytest.ini's single setting into `[tool.pytest.ini_options]` in pyproject.toml, matching how ruff/setuptools/setuptools_scm config already live there rather than in scattered separate files.

## Test plan
- [x] `uv run --locked pytest` passes with the consolidated config (87 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)