### PR TITLE
Add Python 3.13/3.14 to CI test matrix

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v7
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
     - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
     - uses: actions/checkout@v7
     - name: "Set up Python ${{ matrix.python-version }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,10 @@ dynamic         = ["readme", "version"]
 license         = {text = "Apache-2.0"}
 keywords        = ["hydrawise", "api", "iot"]
 classifiers     = [
-    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 


### PR DESCRIPTION
## Summary
- \`pyproject.toml\` declares `requires-python = ">=3.11"` with no upper bound, but CI only ever exercised 3.11/3.12. Python 3.13 and 3.14 are both already released.
- Add both to the build, ruff, and mypy CI matrices, and to the trove classifiers.

## Test plan
- [x] Verified locally with `uv run --python 3.13 ...` and `uv run --python 3.14 ...`: pytest (87 passed), mypy (no issues), and ruff check all clean on both versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)