### PR TITLE
Modernize publish workflow to use uv build/publish

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -17,14 +17,11 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: '3.x'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel twine build
+      - name: Install uv
+        run: python -m pip install uv
       - name: Build and publish
         env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run: |
-          python -m build
-          twine upload dist/*
+          uv build
+          uv publish


### PR DESCRIPTION
## Summary
- Replace the pip/setuptools/wheel/twine/build chain in `publish-python.yml` with `uv build` + `uv publish`, consistent with the rest of the repo's uv-based tooling (`build-and-test.yml`, `uv.lock`).
- `UV_PUBLISH_TOKEN` replaces the twine-specific `TWINE_USERNAME`/`TWINE_PASSWORD` env vars, sourced from the same `PYPI_TOKEN` secret.

## Test plan
- [x] Verified `uv build` locally produces a valid sdist + wheel using the existing setuptools_scm-based build backend
- [ ] Actual publish to PyPI only exercised on a real release event — nothing to test further outside CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)