### PR TITLE
Bump stale pre-commit hook pins

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.0
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         args: [--py310-plus]
         stages: [manual]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-executables-have-shebangs
         stages: [manual]
@@ -16,7 +16,7 @@ repos:
         args:
           - --branch=main
   - repo: https://github.com/cdce8p/python-typing-update
-    rev: v0.7.0
+    rev: v0.8.1
     hooks:
       # Run `python-typing-update` hook manually from time to time
       # to update python typing syntax.
@@ -29,10 +29,10 @@ repos:
           - --force
           - --keep-updates
         files: ^.*\.py$
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.8.1
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.0
     hooks:
-      - id: ruff
+      - id: ruff-check
         args:
           - --fix
       - id: ruff-format


### PR DESCRIPTION
## Summary
- Dependabot only tracks the `uv` and `github-actions` ecosystems (it has no native pre-commit ecosystem), so `.pre-commit-config.yaml` never got auto-updated and drifted well behind versions already in use elsewhere — notably `ruff-pre-commit` was pinned to v0.8.1 while the `ruff==0.16.0` dev dependency in pyproject.toml is what CI actually lints with.
- Bump all four pinned hook revisions to latest (pyupgrade v3.19.0→v3.21.2, pre-commit-hooks v5.0.0→v6.0.0, python-typing-update v0.7.0→v0.8.1, ruff-pre-commit v0.8.1→v0.16.0).
- Move the ruff repo from `charliermarsh/ruff-pre-commit` (now just a redirect) to the canonical `astral-sh/ruff-pre-commit`, and rename the hook id from the deprecated `ruff` legacy alias to `ruff-check`.

Note: the newer ruff-format produces slightly different output than v0.8.1 for a handful of files in this repo. That reformat, plus an unrelated pre-existing formatting gap in docs/usage.md, is handled in a separate PR so this one stays a pure config bump.

## Test plan
- [x] Confirmed this exact set of bumps installs cleanly and `pre-commit run --all-files` (plus `--hook-stage manual`) pass, aside from the expected ruff-format diff called out above

🤖 Generated with [Claude Code](https://claude.com/claude-code)