### PR TITLE
Enable ruff UP/I rules, drop redundant pyupgrade tooling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,4 @@
 repos:
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.0
-    hooks:
-      - id: pyupgrade
-        args: [--py310-plus]
-        stages: [manual]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
@@ -15,20 +9,6 @@ repos:
       - id: no-commit-to-branch
         args:
           - --branch=main
-  - repo: https://github.com/cdce8p/python-typing-update
-    rev: v0.7.0
-    hooks:
-      # Run `python-typing-update` hook manually from time to time
-      # to update python typing syntax.
-      # Will require manual work, before submitting changes!
-      # pre-commit run --hook-stage manual python-typing-update --all-files
-      - id: python-typing-update
-        stages: [manual]
-        args:
-          - --py310-plus
-          - --force
-          - --keep-updates
-        files: ^.*\.py$
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.8.1
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,5 +56,6 @@ force_sort_within_sections = true
 forced_separate            = ["tests"]
 
 [tool.ruff.lint]
+select = ["E4", "E7", "E9", "F", "I", "UP"]
 ignore = ["DTZ", "RUF009"]
 


### PR DESCRIPTION
## Summary
- ruff's config had no explicit \`select\`, so it only ran ruff's bare default rules (E4, E7, E9, F), while two separate manual-stage pre-commit hooks (pyupgrade, python-typing-update) handled syntax modernization that ruff's own \`UP\` rule set already covers — and import sorting had no enforcement at all (isort is orphaned, removed in a companion PR).
- Add \`UP\` (pyupgrade-equivalent) and \`I\` (import sorting) to \`[tool.ruff.lint].select\` alongside the previous defaults, then remove the pyupgrade and python-typing-update repos from \`.pre-commit-config.yaml\` since ruff now covers the same ground via a single \`--fix\` pass.

## Test plan
- [x] \`uv run ruff check .\` — all checks passed, no code changes needed (codebase was already compliant thanks to those two hooks having run historically)
- [x] \`uv run mypy .\` — no issues
- [x] \`uv run pytest\` — 87 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)