### PR TITLE
Fix ruff format non-compliance and add CI format check

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -45,6 +45,9 @@ jobs:
     - name: Run ruff
       run: |
         uv run --locked ruff check --output-format=github .
+    - name: Check formatting
+      run: |
+        uv run --locked ruff format --check .
   mypy:
     runs-on: ubuntu-latest
     strategy:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -94,7 +94,9 @@ print(f"{flow_summary.total_water_volume.value} {flow_summary.total_water_volume
 # Individual watering events (start/end time, duration, water used, why it stopped).
 for entry in await h.get_watering_report(controller, start, end):
     run = entry.run_event
-    print(f"{run.zone.name}: {run.reported_duration} starting {run.reported_start_time}")
+    print(
+        f"{run.zone.name}: {run.reported_duration} starting {run.reported_start_time}"
+    )
 
 # Aggregate water use across all zones, broken down by zone id.
 summary = await h.get_water_use_summary(controller, start, end)

--- a/pydrawise/auth.py
+++ b/pydrawise/auth.py
@@ -55,12 +55,15 @@ class Auth(BaseAuth):
             data["scope"] = "all"
             data["username"] = self.__username
             data["password"] = self.__password
-        async with aiohttp.ClientSession() as session, session.post(
-            TOKEN_URL,
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
-            data=data,
-            timeout=DEFAULT_TIMEOUT,
-        ) as resp:
+        async with (
+            aiohttp.ClientSession() as session,
+            session.post(
+                TOKEN_URL,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                data=data,
+                timeout=DEFAULT_TIMEOUT,
+            ) as resp,
+        ):
             resp_json = await resp.json()
             if "error" in resp_json:
                 self._token = None
@@ -110,13 +113,14 @@ class RestAuth(BaseAuth):
         url = f"{REST_URL}/{path}"
         params = {"api_key": self._api_key}
         params.update(kwargs)
-        async with aiohttp.ClientSession() as session, session.get(
-            url, params=params, timeout=REQUEST_TIMEOUT
-        ) as resp:
-                if resp.status == 404 and await resp.text() == _INVALID_API_KEY:
-                    raise NotAuthorizedError(_INVALID_API_KEY)
-                resp.raise_for_status()
-                return await resp.json()
+        async with (
+            aiohttp.ClientSession() as session,
+            session.get(url, params=params, timeout=REQUEST_TIMEOUT) as resp,
+        ):
+            if resp.status == 404 and await resp.text() == _INVALID_API_KEY:
+                raise NotAuthorizedError(_INVALID_API_KEY)
+            resp.raise_for_status()
+            return await resp.json()
 
     async def check(self) -> bool:
         """Validates that the credentials are valid."""

--- a/pydrawise/client.py
+++ b/pydrawise/client.py
@@ -46,19 +46,21 @@ def _prune_watering_report_entries(
     """
     return list(
         filter(
-            lambda entry: entry.run_event is not None
-            and entry.run_event.reported_start_time is not None
-            and entry.run_event.reported_end_time is not None
-            and (
-                (
-                    start.timestamp()
-                    <= entry.run_event.reported_start_time.timestamp()
-                    <= end.timestamp()
-                )
-                or (
-                    start.timestamp()
-                    <= entry.run_event.reported_end_time.timestamp()
-                    <= end.timestamp()
+            lambda entry: (
+                entry.run_event is not None
+                and entry.run_event.reported_start_time is not None
+                and entry.run_event.reported_end_time is not None
+                and (
+                    (
+                        start.timestamp()
+                        <= entry.run_event.reported_start_time.timestamp()
+                        <= end.timestamp()
+                    )
+                    or (
+                        start.timestamp()
+                        <= entry.run_event.reported_end_time.timestamp()
+                        <= end.timestamp()
+                    )
                 )
             ),
             entries,
@@ -181,7 +183,9 @@ class Hydrawise(HydrawiseBase):
         :rtype: Zone
         """
         result = await self._query(
-            DSL_SCHEMA.Query.zone(zoneId=zone_id).select(*get_selectors(Zone, ["past_runs"]))
+            DSL_SCHEMA.Query.zone(zoneId=zone_id).select(
+                *get_selectors(Zone, ["past_runs"])
+            )
         )
         return deserialize(Zone, result["zone"])
 

--- a/pydrawise/schema.py
+++ b/pydrawise/schema.py
@@ -421,8 +421,8 @@ class ZoneSuspension:
 class Zone(BaseZone):
     """A watering zone."""
 
-    watering_settings: AdvancedWateringSettings | StandardWateringSettings = (
-        field(default_factory=StandardWateringSettings)
+    watering_settings: AdvancedWateringSettings | StandardWateringSettings = field(
+        default_factory=StandardWateringSettings
     )
     scheduled_runs: ScheduledZoneRuns = field(default_factory=ScheduledZoneRuns)
     past_runs: PastZoneRuns = field(default_factory=PastZoneRuns)

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -394,19 +394,27 @@ async def test_get_zones_secondary_controller_rest_error(
     api, hybrid_auth, mock_gql_client, controller_json, zone, status_schedule
 ):
     """NotAuthorizedError on a secondary controller is suppressed if the primary succeeds."""
-    secondary_json = {**controller_json, "id": controller_json["id"] + 1, "name": "Secondary"}
+    secondary_json = {
+        **controller_json,
+        "id": controller_json["id"] + 1,
+        "name": "Secondary",
+    }
     primary = deserialize(Controller, controller_json)
     secondary = deserialize(Controller, secondary_json)
 
     with freeze_time(FROZEN_TIME):
         # Deplete GQL tokens with two fetches so the third falls back to REST.
-        mock_gql_client.get_controllers.return_value = [deepcopy(primary), deepcopy(secondary)]
+        mock_gql_client.get_controllers.return_value = [
+            deepcopy(primary),
+            deepcopy(secondary),
+        ]
         await api.get_controllers()
         await api.get_controllers()
 
         # Third fetch: primary succeeds via REST, secondary raises NotAuthorizedError.
         hybrid_auth.get.side_effect = lambda path, **kw: (
-            status_schedule if kw.get("controller_id") == primary.id
+            status_schedule
+            if kw.get("controller_id") == primary.id
             else (_ for _ in ()).throw(NotAuthorizedError("API key not valid"))
         )
         controllers = await api.get_controllers()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -71,9 +71,9 @@ def test_valid_schema():
                 # TODO: Validate the source type.
                 # got_type = md.deserialization.source
                 continue
-            assert (
-                got_type == want_type
-            ), f"{name}.{f.name} is {got_type}, want {want_type}"
+            assert got_type == want_type, (
+                f"{name}.{f.name} is {got_type}, want {want_type}"
+            )
 
 
 def test_optional_fields():


### PR DESCRIPTION
## Summary
- While auditing tooling, found that CI only ever runs \`ruff check\` (lint) and never \`ruff format --check\`. As a result, 6 files had drifted out of compliance with the already-pinned \`ruff==0.16.0\` dev dependency — 5 .py files (multi-line context managers, a dict-literal wrap, a lambda condition, an assert message) plus an embedded Python code block in \`docs/usage.md\`. This is unrelated to any pre-commit hook version — confirmed it reproduces on plain \`main\` with the existing pinned ruff.
- Run \`ruff format .\` to fix all 6, and add a "Check formatting" step to the \`ruff\` CI job so this can't silently regress again.

## Test plan
- [x] \`uv run ruff format --check .\` — 31 files already formatted (0 remaining)
- [x] \`uv run pytest\` — 87 passed
- [x] \`uv run mypy .\` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)