### PR TITLE
Publish to PyPI via trusted publishing

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -4,8 +4,10 @@ on:
   release:
     types: [published]
 
+permissions: {}
+
 jobs:
-  deploy:
+  build:
 
     runs-on: ubuntu-latest
 
@@ -19,9 +21,27 @@ jobs:
           python-version: '3.x'
       - name: Install uv
         run: python -m pip install uv
-      - name: Build and publish
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          uv build
-          uv publish
+      - name: Build
+        run: uv build
+      - name: Upload distributions
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.14.2


### PR DESCRIPTION
Replaces the long-lived `PYPI_TOKEN` with OIDC trusted publishing, which mints a short-lived token per run and removes the stored secret entirely.

## Changes

- Split the workflow into separate `build` and `publish` jobs so `id-token: write` is scoped to publishing only, with a default-empty `permissions` block at the top level.
- The `publish` job runs in the `pypi` environment to match the trusted publisher configuration.
- Swapped `uv publish` for `pypa/gh-action-pypi-publish`, which supports OIDC and generates PEP 740 attestations by default. Building still uses `uv build`.
- Pinned action versions exactly, matching the rest of the repo so Dependabot can bump them.

## Before merging

- The trusted publisher is already configured on PyPI.
- The `pypi` environment must exist in repo settings and match the trusted publisher's environment name.

## After the first successful release

- Delete the now-unused `PYPI_TOKEN` repository secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)