### PR TITLE
Fix #561: Handle HTTP 403 and redact API key in REST errors

### DIFF
--- a/pydrawise/auth.py
+++ b/pydrawise/auth.py
@@ -122,7 +122,24 @@ class RestAuth(BaseAuth):
         ):
             if resp.status == 404 and await resp.text() == _INVALID_API_KEY:
                 raise NotAuthorizedError(_INVALID_API_KEY)
-            resp.raise_for_status()
+
+            try:
+                resp.raise_for_status()
+            except aiohttp.ClientResponseError as e:
+                if e.status in (401, 403):
+                    # For client-side auth/authz statuses, we don't want to leak
+                    # the API key in the URL that gets logged by ClientResponseError.
+                    # See https://github.com/dknowles2/pydrawise/issues/561
+                    # So we raise NotAuthorizedError instead.
+                    raise NotAuthorizedError(f"HTTP {e.status}") from e
+
+                # Otherwise, redact the API key from the error message.
+                if e.request_info and e.request_info.url:
+                    e.request_info = e.request_info._replace(
+                        url=e.request_info.url.with_query({"api_key": "***"}),
+                        real_url=e.request_info.real_url.with_query({"api_key": "***"}),
+                    )
+                raise
             return await resp.json()
 
     async def check(self) -> bool:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -180,3 +180,21 @@ async def test_rest_auth_raises_for_other_http_errors(mock_server):
     mock_server.add("GET", "/api/v1/customerdetails.php", status=500, body="boom")
     with pytest.raises(ClientResponseError):
         await a.check()
+
+
+async def test_rest_auth_raises_not_authorized_on_403(mock_server):
+    a = auth.RestAuth("__api_key__")
+    mock_server.add("GET", "/api/v1/customerdetails.php", status=403, body="Forbidden")
+    with pytest.raises(NotAuthorizedError, match="HTTP 403"):
+        await a.check()
+
+
+async def test_rest_auth_redacts_api_key_on_other_errors(mock_server):
+    a = auth.RestAuth("__secret_api_key__")
+    mock_server.add("GET", "/api/v1/customerdetails.php", status=500, body="boom")
+    with pytest.raises(ClientResponseError) as exc_info:
+        await a.check()
+
+    error_str = str(exc_info.value)
+    assert "__secret_api_key__" not in error_str
+    assert "api_key=***" in error_str


### PR DESCRIPTION
Fixes #561