### PR TITLE
Fix #561 follow-up: suppress 403 per-controller and redact API key from exception cause

### DIFF
--- a/pydrawise/auth.py
+++ b/pydrawise/auth.py
@@ -126,19 +126,16 @@ class RestAuth(BaseAuth):
             try:
                 resp.raise_for_status()
             except aiohttp.ClientResponseError as e:
-                if e.status in (401, 403):
-                    # For client-side auth/authz statuses, we don't want to leak
-                    # the API key in the URL that gets logged by ClientResponseError.
-                    # See https://github.com/dknowles2/pydrawise/issues/561
-                    # So we raise NotAuthorizedError instead.
-                    raise NotAuthorizedError(f"HTTP {e.status}") from e
-
-                # Otherwise, redact the API key from the error message.
+                # Redact the API key from the error message.
                 if e.request_info and e.request_info.url:
                     e.request_info = e.request_info._replace(
                         url=e.request_info.url.with_query({"api_key": "***"}),
                         real_url=e.request_info.real_url.with_query({"api_key": "***"}),
                     )
+                if e.status in (401, 403):
+                    # For client-side auth/authz statuses, we raise NotAuthorizedError.
+                    # Redaction above ensures the API key doesn't leak via the `__cause__`.
+                    raise NotAuthorizedError(f"HTTP {e.status}") from e
                 raise
             return await resp.json()
 

--- a/pydrawise/hybrid.py
+++ b/pydrawise/hybrid.py
@@ -148,6 +148,7 @@ class HybridClient(HydrawiseBase):
         self._user: User | None = None
         self._controllers: dict[int, Controller] = {}
         self._zones: dict[int, Zone] = {}
+        self._rest_ok: set[int] = set()
         # Per-method result caches used by @throttle, keyed by method name.
         self._throttle_cache: dict[str, dict[str, Any]] = {}
         if gql_throttle is None:
@@ -303,6 +304,7 @@ class HybridClient(HydrawiseBase):
                 )
                 last_err = e
                 continue
+            self._rest_ok.add(controller_id)
             self._rest_throttle.mark()
             self._rest_throttle.epoch_interval = timedelta(seconds=json["nextpoll"])
             zones = []
@@ -320,7 +322,8 @@ class HybridClient(HydrawiseBase):
             self._controllers[controller_id].zones = zones
             succeeded += 1
         if succeeded == 0 and last_err is not None:
-            raise last_err
+            if not (self._rest_ok - set(controller_ids)):
+                raise last_err
 
     @throttle
     async def get_zone(self, zone_id: int) -> Zone:

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -622,14 +622,16 @@ async def test_update_master_valve(api, mock_gql_client, controller, zone):
     await api.update_master_valve(controller, zone)
     mock_gql_client.update_master_valve.assert_awaited_once_with(controller, zone)
 
+
 async def test_update_zones_suppresses_auth_error_if_rest_ok(api, mock_gql_client):
     from unittest.mock import MagicMock
+
     from pydrawise.schema import Controller
-    
+
     # GraphQL gives us 2 controllers, A and B
     c1 = MagicMock(spec=Controller)
     c1.id = 11
-    
+
     c2 = MagicMock(spec=Controller)
     c2.id = 12
 
@@ -643,6 +645,7 @@ async def test_update_zones_suppresses_auth_error_if_rest_ok(api, mock_gql_clien
             return {"nextpoll": 60, "relays": []}
         else:
             from pydrawise.exceptions import NotAuthorizedError
+
             raise NotAuthorizedError("HTTP 403")
 
     api._auth.get.side_effect = mock_get

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -621,3 +621,35 @@ async def test_update_master_valve(api, mock_gql_client, controller, zone):
     """Always delegates to the GraphQL API; the REST API can't set a master valve."""
     await api.update_master_valve(controller, zone)
     mock_gql_client.update_master_valve.assert_awaited_once_with(controller, zone)
+
+async def test_update_zones_suppresses_auth_error_if_rest_ok(api, mock_gql_client):
+    from unittest.mock import MagicMock
+    from pydrawise.schema import Controller
+    
+    # GraphQL gives us 2 controllers, A and B
+    c1 = MagicMock(spec=Controller)
+    c1.id = 11
+    
+    c2 = MagicMock(spec=Controller)
+    c2.id = 12
+
+    api._controllers = {
+        11: c1,
+        12: c2,
+    }
+
+    async def mock_get(path, controller_id, **kwargs):
+        if controller_id == 11:
+            return {"nextpoll": 60, "relays": []}
+        else:
+            from pydrawise.exceptions import NotAuthorizedError
+            raise NotAuthorizedError("HTTP 403")
+
+    api._auth.get.side_effect = mock_get
+
+    # 1. Update zones on C1 successfully. This populates `_rest_ok`.
+    await api._update_zones(api._controllers[11])
+    assert 11 in api._rest_ok
+
+    # 2. Update zones on C2 alone. This hits 403, but is suppressed.
+    await api._update_zones(api._controllers[12])


### PR DESCRIPTION
Addresses the follow-up feedback in #561