### PR TITLE
Auto-bump CalVer version in release drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -14,6 +14,26 @@ jobs:
       contents: write       # create and update the release draft
       pull-requests: read   # read merged PRs to build release notes
     steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0    # need all tags to find the latest release this month
+
+      - name: Compute CalVer version
+        id: calver
+        run: |
+          set -euo pipefail
+          # CalVer: YYYY.M.PATCH, where PATCH restarts at 0 each month.
+          prefix="$(date -u +'%Y.%-m')"
+          latest="$(git tag --list "${prefix}.*" | sort -V | tail -n1)"
+          if [ -z "${latest}" ]; then
+            patch=0
+          else
+            patch=$(( ${latest##*.} + 1 ))
+          fi
+          echo "version=${prefix}.${patch}" >> "$GITHUB_OUTPUT"
+
       - uses: release-drafter/release-drafter@v7.7.0
+        with:
+          version: ${{ steps.calver.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

Release Drafter has no CalVer support. `$RESOLVED_VERSION` only bumps the patch component of the previous tag, so when a month (or year) rolls over the draft release has to be retitled by hand — the current draft is `2026.8.1` even though the next release should be `2026.9.0`.

## Fix

Compute the version in the workflow and pass it to release-drafter via its `version` input, which overrides `$RESOLVED_VERSION` for both `name-template` and `tag-template`:

- `prefix` = current UTC `YYYY.M` (no leading zero, matching the existing tag style).
- Patch = highest existing `prefix.*` tag + 1, or `0` if there are no tags yet this month.

Only published tags are considered, so the draft's version stays stable as PRs merge over the course of a month rather than drifting off its own draft tag.

Requires `actions/checkout` with `fetch-depth: 0` so tags are available.

## Verification

Ran the shell logic against the repo's real tags:

| Month | Latest tag | Computed |
|---|---|---|
| `2026.9` | *(none)* | `2026.9.0` |
| `2026.8` | `2026.8.0` | `2026.8.1` |
| `2024.6` | `2024.6.5` | `2024.6.6` |

Note: the existing stale `2026.8.1` draft won't retitle until the next push to `main`, at which point it becomes `2026.9.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)